### PR TITLE
Update clone instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ PaperPal is a tool for sorting and analyzing research papers based on your perso
 
 1. Clone the repository:
    ```bash
-   git clone https://github.com/yourusername/PaperPal.git
+   git clone https://github.com/M-Chimiste/PaperPal.git
    cd PaperPal
    ```
 


### PR DESCRIPTION
Most repos assume that bash code in a README.md file at the root of a repo is able to be simply copied, pasted, and run. This fix would put your readme in alignment with that. 
The only advantage I can think of to using the placeholder is for folks that have forked the repo, but I would assume that they can replace your username with theirs if they are that knowledgeable. 