### PR TITLE
Adjust podcast page layout width

### DIFF
--- a/theseus-ui/src/pages/Podcast.tsx
+++ b/theseus-ui/src/pages/Podcast.tsx
@@ -171,14 +171,14 @@ const Podcast: React.FC = () => {
   }, [podcastTaskId]);
 
   return (
-    <Container maxWidth="xl" sx={{ mt: 4, mb: 4 }}>
+    <Container maxWidth="lg" sx={{ mt: 4, mb: 4 }}>
       <Typography variant="h4" gutterBottom sx={{ mb: 3 }}>
         🎙️ Podcast Creator
       </Typography>
 
       <Box sx={{ display: 'flex', flexDirection: 'column', gap: 3 }}>
         {/* Content Sources Card - Combined */}
-        <Card sx={{ width: '100%' }}>
+        <Card sx={{ mb: 3 }}>
           <CardContent>
             <Typography variant="h5" gutterBottom sx={{ mb: 2 }}>Content Sources</Typography>
             
@@ -242,7 +242,7 @@ const Podcast: React.FC = () => {
         </Card>
 
         {/* Podcast Model Settings Card */}
-        <Card sx={{ width: '100%' }}>
+        <Card sx={{ mb: 3 }}>
           <CardContent>
             <Box sx={{ display: 'flex', alignItems: 'center', mb: 2 }}>
               <Typography variant="h5" sx={{ flexGrow: 1 }}>Podcast Model Settings</Typography>
@@ -299,7 +299,7 @@ const Podcast: React.FC = () => {
         </Card>
 
         {/* TTS Model Settings Card */}
-        <Card sx={{ width: '100%' }}>
+        <Card sx={{ mb: 3 }}>
           <CardContent>
             <Box sx={{ display: 'flex', alignItems: 'center', mb: 2 }}>
               <Typography variant="h5" sx={{ flexGrow: 1 }}>TTS Model Settings</Typography>
@@ -369,7 +369,7 @@ const Podcast: React.FC = () => {
         </Card>
 
         {/* Intro Music Upload */}
-        <Card sx={{ width: '100%' }}>
+        <Card sx={{ mb: 3 }}>
           <CardContent>
             <Typography variant="h5" gutterBottom>Intro Music (Optional)</Typography>
             <Button variant="outlined" component="label">
@@ -388,7 +388,7 @@ const Podcast: React.FC = () => {
         </Card>
 
         {/* Generate Podcast Button and Status */}
-        <Card sx={{ width: '100%' }}>
+        <Card>
           <CardContent>
             <Typography variant="h5" gutterBottom>Generate</Typography>
             <Button


### PR DESCRIPTION
## Summary
- make the podcast page use a `lg` container like the newsletter page
- remove hard-coded width on cards so they match newsletter spacing

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*