### PR TITLE
Integrate Electron desktop launcher

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,6 +15,7 @@ Theseus Insight is an end‑to‑end platform for analysing research papers and 
 - [Environment Variables](#environment-variables)
 - [Running the API](#running-the-api)
 - [Running the Frontend](#running-the-frontend)
+- [Running as a Desktop App with Electron](#running-as-a-desktop-app-with-electron)
 - [Key Endpoints](#key-endpoints)
   - [PDF Uploads](#pdf-uploads)
   - [Podcast Generation](#podcast-generation)
@@ -137,7 +138,20 @@ Interactive docs are served at [http://localhost:8000/docs](http://localhost:800
 
 ## Running the Frontend
 
+
 During development use the Vite dev server as shown in the [Quickstart](#quickstart) section.  When using Docker or after running `npm run build`, the compiled frontend is served automatically from FastAPI on port 8000.
+
+## Running as a Desktop App with Electron
+
+An Electron entry point is provided to bundle the React UI with the Python backend. After building the frontend, launch the desktop app with:
+
+```bash
+cd theseus-ui
+npm run build
+npm run electron
+```
+
+The Electron main process starts the FastAPI server automatically and loads the interface in a desktop window.
 
 ---
 

--- a/theseus-ui/electron.js
+++ b/theseus-ui/electron.js
@@ -1,0 +1,61 @@
+const { app, BrowserWindow } = require('electron');
+const { spawn } = require('child_process');
+const path = require('path');
+
+let backendProcess;
+
+function startBackend() {
+  const rootDir = path.join(__dirname, '..');
+  backendProcess = spawn('python', ['-m', 'uvicorn', 'theseus_insight.main:app', '--port', '8000'], {
+    cwd: rootDir,
+  });
+
+  backendProcess.stdout.on('data', (data) => {
+    console.log(`[backend]: ${data}`.trim());
+  });
+
+  backendProcess.stderr.on('data', (data) => {
+    console.error(`[backend error]: ${data}`.trim());
+  });
+}
+
+function createWindow() {
+  const win = new BrowserWindow({
+    width: 1200,
+    height: 800,
+    webPreferences: {
+      contextIsolation: true,
+    },
+  });
+
+  const isDev = !app.isPackaged;
+  if (isDev) {
+    win.loadURL('http://localhost:5173');
+    win.webContents.openDevTools();
+  } else {
+    win.loadFile(path.join(__dirname, 'dist', 'index.html'));
+  }
+}
+
+app.whenReady().then(() => {
+  startBackend();
+  createWindow();
+
+  app.on('activate', () => {
+    if (BrowserWindow.getAllWindows().length === 0) {
+      createWindow();
+    }
+  });
+});
+
+app.on('window-all-closed', () => {
+  if (process.platform !== 'darwin') {
+    app.quit();
+  }
+});
+
+app.on('before-quit', () => {
+  if (backendProcess) {
+    backendProcess.kill();
+  }
+});

--- a/theseus-ui/package.json
+++ b/theseus-ui/package.json
@@ -3,11 +3,13 @@
   "private": true,
   "version": "0.0.0",
   "type": "module",
+  "main": "electron.js",
   "scripts": {
     "dev": "vite",
     "build": "tsc -b && vite build",
     "lint": "eslint .",
-    "preview": "vite preview"
+    "preview": "vite preview",
+    "electron": "electron ."
   },
   "dependencies": {
     "@emotion/react": "^11.14.0",
@@ -34,6 +36,7 @@
     "globals": "^16.0.0",
     "typescript": "~5.8.3",
     "typescript-eslint": "^8.30.1",
-    "vite": "^6.3.5"
+    "vite": "^6.3.5",
+    "electron": "^30.0.0"
   }
 }


### PR DESCRIPTION
## Summary
- add electron main process to launch the React UI and Python API together
- extend `package.json` with electron entry and dev dependency
- document desktop usage

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*
- `npm run build` *(fails: missing dependencies)*
- `pytest`