### PR TITLE
Collapse filter bar after applying filters

### DIFF
--- a/theseus-ui/src/pages/Papers.tsx
+++ b/theseus-ui/src/pages/Papers.tsx
@@ -276,6 +276,7 @@ const Papers: React.FC = () => {
 
   const handleApplyFilters = () => {
     setAppliedFilters({ ...filters });
+    setShowFilters(false);
   };
 
   const handleSearchKeyDown = (e: React.KeyboardEvent<HTMLDivElement>) => {


### PR DESCRIPTION
## Summary
- hide Papers search/filter section when filters are applied

## Testing
- `npm run build` *(fails: Cannot find module 'react-router-dom')*
- `python -m theseus_insight.utils.db_migration.test_migration` *(fails: No module named 'pandas')*