### PR TITLE
Add database setup utility script

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -331,6 +331,7 @@ music/
 # Scripts
 *.sh
 !examples/*.sh
+!scripts/setup_database.sh
 
 #checkpoints
 checkpoints/

--- a/README.md
+++ b/README.md
@@ -104,6 +104,7 @@ If you prefer running locally without Docker:
    npm run build
    ```
 3. Configure environment variables as shown below.
+4. Run `scripts/setup_database.sh` to create the default PostgreSQL database and role.
 
 ---
 

--- a/scripts/setup_database.sh
+++ b/scripts/setup_database.sh
@@ -1,0 +1,36 @@
+#!/usr/bin/env bash
+# Set up PostgreSQL role and database for Theseus Insight
+
+set -euo pipefail
+
+DB_USER="${DB_USER:-theseus}"
+DB_PASS="${DB_PASS:-theseus}"
+DB_NAME="${DB_NAME:-theseusdb}"
+
+# Commands will be executed as the postgres superuser
+# Usage: run this script with a superuser account that can run `psql`
+
+psql -v ON_ERROR_STOP=1 <<SQL
+DO
+\$
+BEGIN
+   IF NOT EXISTS (
+      SELECT FROM pg_catalog.pg_roles WHERE rolname = '${DB_USER}'
+   ) THEN
+      CREATE ROLE ${DB_USER} LOGIN PASSWORD '${DB_PASS}';
+      ALTER ROLE ${DB_USER} CREATEDB;
+   END IF;
+END
+\$;
+
+IF NOT EXISTS (
+    SELECT FROM pg_database WHERE datname = '${DB_NAME}'
+) THEN
+    CREATE DATABASE ${DB_NAME} OWNER ${DB_USER};
+END IF;
+SQL
+
+# Enable pgvector extension on the new database
+psql -v ON_ERROR_STOP=1 -d "$DB_NAME" -c "CREATE EXTENSION IF NOT EXISTS vector;"
+
+echo "Database \"$DB_NAME\" and role \"$DB_USER\" are ready."


### PR DESCRIPTION
## Summary
- provide `scripts/setup_database.sh` for initial PostgreSQL setup
- allow the new script via `.gitignore`
- document running the script in the Installation section of the README

## Testing
- `python theseus_insight/utils/db_migration/test_migration.py`