### PR TITLE
Improve success banner UX

### DIFF
--- a/theseus-ui/src/pages/Settings.tsx
+++ b/theseus-ui/src/pages/Settings.tsx
@@ -13,6 +13,7 @@ import {
   FormControlLabel,
   Button,
   Alert,
+  Snackbar,
   CircularProgress,
   Container,
   Tabs,
@@ -343,16 +344,26 @@ const Settings: React.FC = () => {
 
   return (
     <Container maxWidth="lg" sx={{ mt: 4, mb: 4 }}>
-      {error && (
-        <Alert severity="error" sx={{ mb: 2 }} onClose={() => setError(null)}>
+      <Snackbar
+        open={Boolean(error)}
+        autoHideDuration={4000}
+        onClose={() => setError(null)}
+        anchorOrigin={{ vertical: 'top', horizontal: 'right' }}
+      >
+        <Alert onClose={() => setError(null)} severity="error" sx={{ width: '100%' }}>
           {error}
         </Alert>
-      )}
-      {success && (
-        <Alert severity="success" sx={{ mb: 2 }} onClose={() => setSuccess(null)}>
+      </Snackbar>
+      <Snackbar
+        open={Boolean(success)}
+        autoHideDuration={4000}
+        onClose={() => setSuccess(null)}
+        anchorOrigin={{ vertical: 'top', horizontal: 'right' }}
+      >
+        <Alert onClose={() => setSuccess(null)} severity="success" sx={{ width: '100%' }}>
           {success}
         </Alert>
-      )}
+      </Snackbar>
 
         <Typography variant="h4" gutterBottom component="div" sx={{ mb: 3 }}>
           <SettingsIcon sx={{ mr: 1, verticalAlign: 'middle' }}/> Settings


### PR DESCRIPTION
## Summary
- use a `Snackbar` so success notifications appear in the top-right of the current view
- also show error notifications via a `Snackbar`

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*
