### PR TITLE
Implement basic task queue

### DIFF
--- a/theseus_insight/api/tasks.py
+++ b/theseus_insight/api/tasks.py
@@ -18,15 +18,51 @@ class TaskManager:
     def __init__(self):
         self.status_updates: Dict[str, List[asyncio.Queue]] = {}
         self.db = PaperDatabase(os.getenv("DATABASE_URL", "postgresql://theseus:theseus@localhost:5432/theseusdb"))
-        
+
+        # Queue for incoming tasks and worker management
+        self.task_queue: asyncio.Queue = asyncio.Queue()
+        self.worker_task: Optional[asyncio.Task] = None
+
         # Mark any interrupted tasks as failed on startup
-        interrupted_count = self.db.mark_interrupted_tasks_as_failed()
-        
+        self.db.mark_interrupted_tasks_as_failed()
+
         # Clean up old tasks on startup
         self.db.cleanup_old_tasks(days_old=7)
+
+    async def start_worker(self) -> None:
+        """Start the background worker that processes queued tasks."""
+        if self.worker_task is None or self.worker_task.done():
+            self.worker_task = asyncio.create_task(self._worker())
+
+    async def stop_worker(self) -> None:
+        """Stop the background worker gracefully."""
+        if self.worker_task:
+            await self.task_queue.put(None)
+            await self.worker_task
+            self.worker_task = None
+
+    async def _worker(self) -> None:
+        """Continuously process tasks from the queue."""
+        while True:
+            item = await self.task_queue.get()
+            if item is None:
+                self.task_queue.task_done()
+                break
+            func, task_id = item
+            try:
+                await func(task_id)
+            finally:
+                self.task_queue.task_done()
+
+    async def enqueue_task(self, func, task_id: str) -> None:
+        """Add a new task to the processing queue."""
+        await self.task_queue.put((func, task_id))
         
     async def cleanup(self):
         """Clean up all asyncio resources."""
+        # Stop worker processing
+        await self.stop_worker()
+
         # First, notify all waiting consumers to exit
         for task_id, queues in self.status_updates.items():
             for queue in queues:

--- a/theseus_insight/main.py
+++ b/theseus_insight/main.py
@@ -174,6 +174,8 @@ async def lifespan(app_instance: FastAPI):
             
     except Exception as e:
         print(f"Error during startup: {e}")
+    # Start background worker for queued tasks
+    await task_manager.start_worker()
     print("INFO:     Theseus Insight API startup complete.")
     yield
     # Shutdown logic
@@ -1131,7 +1133,7 @@ async def run_newsletter(
             task_type="newsletter",
             config=newsletter_config.dict()
         )
-        background_tasks.add_task(task_manager.run_newsletter_task, task_id)
+        await task_manager.enqueue_task(task_manager.run_newsletter_task, task_id)
         
         return {"taskId": task_id}
     except ValueError as e:
@@ -1222,7 +1224,7 @@ async def generate_podcast_pipeline(
         # 3. Handle URL fetching and conversion to PDF if input_type is 'urls' (this is complex).
         #    For now, this implementation primarily supports 'pdfs' directly for PodcastGenerator.
         #    If 'urls' are passed, 'run_podcast_task' needs to manage downloading/converting them to PDF paths.
-        background_tasks.add_task(task_manager.run_podcast_task, task_id)
+        await task_manager.enqueue_task(task_manager.run_podcast_task, task_id)
         
         return {"task_id": task_id, "message": "Podcast generation process initiated."}
     
@@ -1273,7 +1275,7 @@ async def run_visualizer_pipeline_endpoint(
             config=task_config
         )
         
-        background_tasks.add_task(task_manager.run_visualizer_task, task_id)
+        await task_manager.enqueue_task(task_manager.run_visualizer_task, task_id)
         
         return {"task_id": task_id, "message": "Visualizer generation process initiated."}
     except json.JSONDecodeError:
@@ -1639,7 +1641,7 @@ async def run_newsletter_pipeline_endpoint(
                 )
             print(error_message) # Log to server console as well
 
-    background_tasks.add_task(background_pipeline_run)
+    await task_manager.enqueue_task(lambda _tid: background_pipeline_run(), task_id)
     return {"task_id": task_id, "message": "Newsletter generation process has been initiated."}
 
 # --- Serve React Frontend --- #


### PR DESCRIPTION
## Summary
- add an `asyncio` queue inside `TaskManager`
- spin up a worker on startup that processes queued tasks
- enqueue newsletter, podcast and visualizer tasks instead of running them directly

## Testing
- `python -m py_compile $(git ls-files '*.py')`
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'pandas')*