### PR TITLE
Allow visualizer task concurrency

### DIFF
--- a/theseus_insight/api/tasks.py
+++ b/theseus_insight/api/tasks.py
@@ -19,9 +19,13 @@ class TaskManager:
         self.status_updates: Dict[str, List[asyncio.Queue]] = {}
         self.db = PaperDatabase(os.getenv("DATABASE_URL", "postgresql://theseus:theseus@localhost:5432/theseusdb"))
 
-        # Queue for incoming tasks and worker management
-        self.task_queue: asyncio.Queue = asyncio.Queue()
-        self.worker_task: Optional[asyncio.Task] = None
+        # Queues and workers for task processing
+        # general_task_queue handles newsletter/podcast/etc.
+        # visualizer_queue allows a visualizer task to run concurrently
+        self.general_task_queue: asyncio.Queue = asyncio.Queue()
+        self.visualizer_queue: asyncio.Queue = asyncio.Queue()
+        self.general_worker_task: Optional[asyncio.Task] = None
+        self.visualizer_worker_task: Optional[asyncio.Task] = None
 
         # Mark any interrupted tasks as failed on startup
         self.db.mark_interrupted_tasks_as_failed()
@@ -30,33 +34,40 @@ class TaskManager:
         self.db.cleanup_old_tasks(days_old=7)
 
     async def start_worker(self) -> None:
-        """Start the background worker that processes queued tasks."""
-        if self.worker_task is None or self.worker_task.done():
-            self.worker_task = asyncio.create_task(self._worker())
+        """Start the background workers that process queued tasks."""
+        if self.general_worker_task is None or self.general_worker_task.done():
+            self.general_worker_task = asyncio.create_task(self._worker(self.general_task_queue))
+        if self.visualizer_worker_task is None or self.visualizer_worker_task.done():
+            self.visualizer_worker_task = asyncio.create_task(self._worker(self.visualizer_queue))
 
     async def stop_worker(self) -> None:
-        """Stop the background worker gracefully."""
-        if self.worker_task:
-            await self.task_queue.put(None)
-            await self.worker_task
-            self.worker_task = None
+        """Stop the background workers gracefully."""
+        if self.general_worker_task:
+            await self.general_task_queue.put(None)
+            await self.general_worker_task
+            self.general_worker_task = None
+        if self.visualizer_worker_task:
+            await self.visualizer_queue.put(None)
+            await self.visualizer_worker_task
+            self.visualizer_worker_task = None
 
-    async def _worker(self) -> None:
-        """Continuously process tasks from the queue."""
+    async def _worker(self, queue: asyncio.Queue) -> None:
+        """Continuously process tasks from the given queue."""
         while True:
-            item = await self.task_queue.get()
+            item = await queue.get()
             if item is None:
-                self.task_queue.task_done()
+                queue.task_done()
                 break
             func, task_id = item
             try:
                 await func(task_id)
             finally:
-                self.task_queue.task_done()
+                queue.task_done()
 
-    async def enqueue_task(self, func, task_id: str) -> None:
-        """Add a new task to the processing queue."""
-        await self.task_queue.put((func, task_id))
+    async def enqueue_task(self, func, task_id: str, visualizer: bool = False) -> None:
+        """Add a new task to the appropriate processing queue."""
+        queue = self.visualizer_queue if visualizer or func == self.run_visualizer_task else self.general_task_queue
+        await queue.put((func, task_id))
         
     async def cleanup(self):
         """Clean up all asyncio resources."""

--- a/theseus_insight/main.py
+++ b/theseus_insight/main.py
@@ -1275,7 +1275,7 @@ async def run_visualizer_pipeline_endpoint(
             config=task_config
         )
         
-        await task_manager.enqueue_task(task_manager.run_visualizer_task, task_id)
+        await task_manager.enqueue_task(task_manager.run_visualizer_task, task_id, visualizer=True)
         
         return {"task_id": task_id, "message": "Visualizer generation process initiated."}
     except json.JSONDecodeError:


### PR DESCRIPTION
## Summary
- split task workers so visualizer jobs can run in parallel with other tasks
- queue visualizer requests on their own worker

## Testing
- `python -m py_compile theseus_insight/api/tasks.py theseus_insight/main.py`
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'pandas')*