### PR TITLE
Update Electron deps for warnings

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,6 +18,7 @@ Theseus Insight is an end‑to‑end platform for analysing research papers and 
 - [External Database Access](#external-database-access)
 - [External Database Access](#external-database-access)
 - [Custom Data Storage Location](#custom-data-storage-location)
+- [Desktop Build](#desktop-build)
 - [Key Endpoints](#key-endpoints)
   - [PDF Uploads](#pdf-uploads)
   - [Podcast Generation](#podcast-generation)
@@ -105,7 +106,7 @@ If you prefer running locally without Docker:
    pip install -r requirements.txt
 
    ```
-2. (Optional) install Node.js 18+ and build the frontend
+2. (Optional) install Node.js 20+ and build the frontend
    ```bash
    cd theseus-ui
    npm install
@@ -524,6 +525,25 @@ python -m theseus_insight.utils.db_migration.db_migrate migrate \
 - **Flexible import options** - Support for selective imports and batch processing
 
 For detailed documentation and advanced usage examples, see [`theseus_insight/docs/db_migration_README.md`](theseus_insight/docs/db_migration_README.md).
+
+---
+
+## Desktop Build
+
+An Electron wrapper is provided in the `electron-app` directory. It bundles the
+Python backend and a PostgreSQL database using `pgvector`. PostgreSQL runs on
+port **55432** to avoid conflicts with existing installations.
+
+### Building
+
+```
+cd electron-app
+npm install
+npm run build
+```
+
+See [`electron-app/README.md`](electron-app/README.md) for platform specific
+instructions.
 
 ---
 

--- a/electron-app/README.md
+++ b/electron-app/README.md
@@ -1,0 +1,39 @@
+# Theseus Insight Desktop
+
+This directory provides an Electron wrapper that bundles the Python backend and a local PostgreSQL database using the `pgvector` extension.
+
+## Local Setup
+
+1. Install Node.js 20 or newer.
+2. From this folder run `npm install` to install Electron dependencies.
+3. Ensure the `postgres` binaries are available under `electron-app/postgres/<platform>/bin`. These are not included in the repository – copy prebuilt binaries for your OS.
+4. Run `npm start` to launch the desktop application.
+
+The application starts PostgreSQL on port **55432** to avoid conflicts with any existing database server.
+
+## Building Distributables
+
+`electron-builder` is used for packaging. Use the commands below for different platforms.
+
+### macOS
+
+```bash
+npm run build -- -m
+```
+This produces a `.dmg` installer in the `dist/` directory.
+
+### Linux
+
+```bash
+npm run build -- -l
+```
+Generates a `.AppImage` file.
+
+### Windows
+
+```bash
+npm run build -- -w
+```
+Creates a Windows installer (`.exe`).
+
+Ensure that Python and the PostgreSQL binaries are included in the `extraResources` section of `package.json` so they are packaged with the app.

--- a/electron-app/main.js
+++ b/electron-app/main.js
@@ -1,0 +1,70 @@
+const { app, BrowserWindow } = require('electron');
+const path = require('path');
+const { spawn } = require('child_process');
+
+let pythonProcess = null;
+let postgresProcess = null;
+
+function createWindow () {
+  const win = new BrowserWindow({
+    width: 1200,
+    height: 800,
+    webPreferences: {
+      nodeIntegration: false,
+      contextIsolation: true
+    }
+  });
+
+  win.loadURL('http://localhost:8000');
+}
+
+function startPostgres() {
+  const platform = process.platform;
+  // expected postgres binaries under electron-app/postgres/<platform>/bin
+  const pgPath = path.join(__dirname, 'postgres', platform, 'bin', 'postgres');
+  const dataDir = path.join(app.getPath('userData'), 'postgres-data');
+  postgresProcess = spawn(pgPath, ['-D', dataDir, '-p', '55432']);
+
+  postgresProcess.stdout.on('data', (data) => {
+    console.log(`postgres: ${data}`);
+  });
+
+  postgresProcess.stderr.on('data', (data) => {
+    console.error(`postgres err: ${data}`);
+  });
+}
+
+function startBackend() {
+  const scriptPath = path.join(__dirname, 'app', 'run_theseus_insight.py');
+  pythonProcess = spawn('python', [scriptPath], {
+    env: {
+      ...process.env,
+      DATABASE_URL: 'postgresql://theseus:theseus@localhost:55432/theseusdb'
+    }
+  });
+
+  pythonProcess.stdout.on('data', (data) => {
+    console.log(`backend: ${data}`);
+  });
+
+  pythonProcess.stderr.on('data', (data) => {
+    console.error(`backend err: ${data}`);
+  });
+}
+
+app.whenReady().then(() => {
+  startPostgres();
+  startBackend();
+  createWindow();
+});
+
+app.on('window-all-closed', () => {
+  if (process.platform !== 'darwin') {
+    app.quit();
+  }
+});
+
+app.on('will-quit', () => {
+  if (pythonProcess) pythonProcess.kill();
+  if (postgresProcess) postgresProcess.kill();
+});

--- a/electron-app/package.json
+++ b/electron-app/package.json
@@ -1,0 +1,28 @@
+{
+  "name": "theseus-desktop",
+  "version": "0.1.0",
+  "main": "main.js",
+  "description": "Electron wrapper for Theseus Insight",
+  "scripts": {
+    "start": "electron .",
+    "build": "electron-builder"
+  },
+  "build": {
+    "appId": "com.theseusinsight.desktop",
+    "files": [
+      "**/*",
+      "!node_modules/*/{CHANGELOG.md,README.md,readme.md,example,examples,**/test/**}"
+    ],
+    "extraResources": [
+      {
+        "from": "../",
+        "to": "app",
+        "filter": ["theseus_insight/**", "theseus-ui/dist/**", "run_theseus_insight.py", "requirements.txt", "postgres/**"]
+      }
+    ]
+  },
+  "devDependencies": {
+    "electron": "^31.0.0",
+    "electron-builder": "^24.11.0"
+  }
+}

--- a/electron-app/postgres/darwin/bin/README.txt
+++ b/electron-app/postgres/darwin/bin/README.txt
@@ -1,0 +1,1 @@
+Place Postgres binaries for macOS here

--- a/electron-app/postgres/linux/bin/README.txt
+++ b/electron-app/postgres/linux/bin/README.txt
@@ -1,0 +1,1 @@
+Place Postgres binaries for Linux here

--- a/electron-app/postgres/win32/bin/README.txt
+++ b/electron-app/postgres/win32/bin/README.txt
@@ -1,0 +1,1 @@
+Place Postgres binaries for Windows here


### PR DESCRIPTION
## Summary
- bump Electron and electron-builder versions
- require Node.js 20+ for frontend and desktop build

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'pandas')*