### PR TITLE
Add build scripts for Postgres and update Electron docs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -422,3 +422,7 @@ dist-ssr
 *.njsproj
 *.sln
 *.sw?
+
+# Electron PostgreSQL binaries
+/electron-app/postgres/
+

--- a/README.md
+++ b/README.md
@@ -18,6 +18,7 @@ Theseus Insight is an end‑to‑end platform for analysing research papers and 
 - [External Database Access](#external-database-access)
 - [External Database Access](#external-database-access)
 - [Custom Data Storage Location](#custom-data-storage-location)
+- [Desktop Build](#desktop-build)
 - [Key Endpoints](#key-endpoints)
   - [PDF Uploads](#pdf-uploads)
   - [Podcast Generation](#podcast-generation)
@@ -105,7 +106,7 @@ If you prefer running locally without Docker:
    pip install -r requirements.txt
 
    ```
-2. (Optional) install Node.js 18+ and build the frontend
+2. (Optional) install Node.js 20+ and build the frontend
    ```bash
    cd theseus-ui
    npm install
@@ -524,6 +525,26 @@ python -m theseus_insight.utils.db_migration.db_migrate migrate \
 - **Flexible import options** - Support for selective imports and batch processing
 
 For detailed documentation and advanced usage examples, see [`theseus_insight/docs/db_migration_README.md`](theseus_insight/docs/db_migration_README.md).
+
+---
+
+## Desktop Build
+
+An Electron wrapper is provided in the `electron-app` directory. It bundles the
+Python backend and a PostgreSQL database using `pgvector`. PostgreSQL runs on
+port **55432** to avoid conflicts with existing installations.
+
+### Building
+
+```
+cd electron-app
+npm install
+npm run build-pg   # or npm run download-pg
+npm run build
+```
+
+See [`electron-app/README.md`](electron-app/README.md) for platform specific
+instructions.
 
 ---
 

--- a/electron-app/README.md
+++ b/electron-app/README.md
@@ -1,0 +1,39 @@
+# Theseus Insight Desktop
+
+This directory provides an Electron wrapper that bundles the Python backend and a local PostgreSQL database using the `pgvector` extension.
+
+## Local Setup
+
+1. Install **Node.js 20** or newer.
+2. Run `npm install` to install Electron dependencies.
+3. Build or download PostgreSQL (with the `pgvector` extension) by running either `npm run build-pg` to compile from source or `npm run download-pg` to fetch prebuilt binaries.
+4. Run `npm start` to launch the desktop application.
+
+The application starts PostgreSQL on port **55432** to avoid conflicts with any existing database server.
+
+## Building Distributables
+
+`electron-builder` is used for packaging. Run `npm run build-pg` (or `npm run download-pg`) once before packaging. Use the commands below for different platforms.
+
+### macOS
+
+```bash
+npm run build -- -m
+```
+This produces a `.dmg` installer in the `dist/` directory.
+
+### Linux
+
+```bash
+npm run build -- -l
+```
+Generates a `.AppImage` file.
+
+### Windows
+
+```bash
+npm run build -- -w
+```
+Creates a Windows installer (`.exe`).
+
+Ensure that Python and the PostgreSQL binaries are included in the `extraResources` section of `package.json` so they are packaged with the app.

--- a/electron-app/build_postgres.sh
+++ b/electron-app/build_postgres.sh
@@ -1,0 +1,31 @@
+#!/usr/bin/env bash
+# Build PostgreSQL and pgvector from source for the current platform.
+set -euo pipefail
+
+VERSION="16.2"
+PLATFORM="$(uname | tr 'A-Z' 'a-z')"
+PREFIX="$(dirname "$0")/postgres/${PLATFORM}"
+mkdir -p "$PREFIX"
+
+SRC_DIR="$(mktemp -d)"
+trap 'rm -rf "$SRC_DIR"' EXIT
+
+cd "$SRC_DIR"
+curl -L "https://ftp.postgresql.org/pub/source/v${VERSION}/postgresql-${VERSION}.tar.gz" -o pg.tar.gz
+
+tar -xzf pg.tar.gz
+cd postgresql-${VERSION}
+./configure --prefix="$PREFIX"
+make -j$(nproc)
+make install
+cd ..
+
+git clone --depth 1 https://github.com/pgvector/pgvector.git
+cd pgvector
+make PG_CONFIG="$PREFIX/bin/pg_config"
+make install PG_CONFIG="$PREFIX/bin/pg_config"
+
+cd ..
+rm -rf pg.tar.gz postgresql-${VERSION} pgvector
+
+echo "PostgreSQL built and installed to $PREFIX"

--- a/electron-app/download_postgres.sh
+++ b/electron-app/download_postgres.sh
@@ -1,0 +1,36 @@
+#!/usr/bin/env bash
+# Download prebuilt PostgreSQL binaries for the current platform.
+set -euo pipefail
+
+VERSION="16.2"
+PLATFORM="$(uname | tr 'A-Z' 'a-z')"
+TARGET_DIR="$(dirname "$0")/postgres/${PLATFORM}"
+mkdir -p "$TARGET_DIR"
+
+case "$PLATFORM" in
+  darwin)
+    URL="https://get.enterprisedb.com/postgresql/postgresql-${VERSION}-1-osx-binaries.tar.gz"
+    ;;
+  linux)
+    URL="https://get.enterprisedb.com/postgresql/postgresql-${VERSION}-1-linux-x64-binaries.tar.gz"
+    ;;
+  msys*|mingw*|cygwin*|win32)
+    URL="https://get.enterprisedb.com/postgresql/postgresql-${VERSION}-1-windows-x64-binaries.zip"
+    ;;
+  *)
+    echo "Unsupported platform $PLATFORM" >&2
+    exit 1
+    ;;
+esac
+
+echo "Downloading PostgreSQL ${VERSION} for $PLATFORM..."
+TMP_FILE="/tmp/postgresql-${VERSION}.tar.gz"
+curl -L "$URL" -o "$TMP_FILE"
+
+if [[ "$TMP_FILE" == *.zip ]]; then
+  unzip -q "$TMP_FILE" -d "$TARGET_DIR"
+else
+  tar -xzf "$TMP_FILE" -C "$TARGET_DIR" --strip-components=1
+fi
+
+echo "PostgreSQL binaries extracted to $TARGET_DIR"

--- a/electron-app/main.js
+++ b/electron-app/main.js
@@ -1,0 +1,78 @@
+const { app, BrowserWindow } = require('electron');
+const path = require('path');
+const { spawn, spawnSync } = require('child_process');
+const fs = require('fs');
+
+let pythonProcess = null;
+let postgresProcess = null;
+
+function createWindow () {
+  const win = new BrowserWindow({
+    width: 1200,
+    height: 800,
+    webPreferences: {
+      nodeIntegration: false,
+      contextIsolation: true
+    }
+  });
+
+  win.loadURL('http://localhost:8000');
+}
+
+function startPostgres() {
+  const platform = process.platform;
+  // expected postgres binaries under electron-app/postgres/<platform>/bin
+  const binDir = path.join(__dirname, 'postgres', platform, 'bin');
+  const pgPath = path.join(binDir, platform === 'win32' ? 'postgres.exe' : 'postgres');
+  const initdbPath = path.join(binDir, platform === 'win32' ? 'initdb.exe' : 'initdb');
+  const dataDir = path.join(app.getPath('userData'), 'postgres-data');
+
+  if (!fs.existsSync(path.join(dataDir, 'PG_VERSION'))) {
+    spawnSync(initdbPath, ['-D', dataDir]);
+  }
+
+  postgresProcess = spawn(pgPath, ['-D', dataDir, '-p', '55432']);
+
+  postgresProcess.stdout.on('data', (data) => {
+    console.log(`postgres: ${data}`);
+  });
+
+  postgresProcess.stderr.on('data', (data) => {
+    console.error(`postgres err: ${data}`);
+  });
+}
+
+function startBackend() {
+  const scriptPath = path.join(__dirname, 'app', 'run_theseus_insight.py');
+  pythonProcess = spawn('python', [scriptPath], {
+    env: {
+      ...process.env,
+      DATABASE_URL: 'postgresql://theseus:theseus@localhost:55432/theseusdb'
+    }
+  });
+
+  pythonProcess.stdout.on('data', (data) => {
+    console.log(`backend: ${data}`);
+  });
+
+  pythonProcess.stderr.on('data', (data) => {
+    console.error(`backend err: ${data}`);
+  });
+}
+
+app.whenReady().then(() => {
+  startPostgres();
+  startBackend();
+  createWindow();
+});
+
+app.on('window-all-closed', () => {
+  if (process.platform !== 'darwin') {
+    app.quit();
+  }
+});
+
+app.on('will-quit', () => {
+  if (pythonProcess) pythonProcess.kill();
+  if (postgresProcess) postgresProcess.kill();
+});

--- a/electron-app/package.json
+++ b/electron-app/package.json
@@ -1,0 +1,33 @@
+{
+  "name": "theseus-desktop",
+  "version": "0.1.0",
+  "main": "main.js",
+  "description": "Electron wrapper for Theseus Insight",
+  "scripts": {
+    "start": "electron .",
+    "build": "electron-builder",
+    "download-pg": "bash ./download_postgres.sh",
+    "build-pg": "bash ./build_postgres.sh"
+  },
+  "build": {
+    "appId": "com.theseusinsight.desktop",
+    "files": [
+      "**/*",
+      "!node_modules/*/{CHANGELOG.md,README.md,readme.md,example,examples,**/test/**}"
+    ],
+    "extraResources": [
+      {
+        "from": "../",
+        "to": "app",
+        "filter": ["theseus_insight/**", "theseus-ui/dist/**", "run_theseus_insight.py", "requirements.txt", "postgres/**"]
+      }
+    ]
+  },
+  "engines": {
+    "node": ">=20"
+  },
+  "devDependencies": {
+    "electron": "^31.0.0",
+    "electron-builder": "^24.11.0"
+  }
+}

--- a/electron-app/postgres/.gitignore
+++ b/electron-app/postgres/.gitignore
@@ -1,0 +1,3 @@
+# ignore compiled postgres binaries
+*
+!.gitignore


### PR DESCRIPTION
## Summary
- provide shell scripts to download or compile Postgres with pgvector
- ignore Postgres binaries in git
- update Electron wrapper to use build scripts
- instruct Node.js 20+ usage and document build-pg/download-pg workflow

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'pandas')*