### PR TITLE
Fix postgres path for packaged Electron app

### DIFF
--- a/electron-app/main.js
+++ b/electron-app/main.js
@@ -120,8 +120,10 @@ function createWindow () {
 
 function startPostgres() {
   const platform = process.platform;
+  const isPackaged = app.isPackaged;
   // expected postgres binaries under electron-app/postgres/<platform>/bin
-  const binDir = path.join(__dirname, 'postgres', platform, 'bin');
+  const baseDir = isPackaged ? path.join(process.resourcesPath, 'app') : __dirname;
+  const binDir = path.join(baseDir, 'postgres', platform, 'bin');
   const pgPath = path.join(binDir, platform === 'win32' ? 'postgres.exe' : 'postgres');
   const initdbPath = path.join(binDir, platform === 'win32' ? 'initdb.exe' : 'initdb');
   const dataDir = path.join(app.getPath('userData'), 'postgres-data');

--- a/electron-app/package.json
+++ b/electron-app/package.json
@@ -34,10 +34,13 @@
           "theseus_insight/**", 
           "theseus-ui/dist/**", 
           "config/**", 
-          "run_theseus_insight.py", 
-          "requirements.txt", 
-          "postgres/**"
+          "run_theseus_insight.py",
+          "requirements.txt"
         ]
+      },
+      {
+        "from": "postgres",
+        "to": "app/postgres"
       },
       {
         "from": "env.template",


### PR DESCRIPTION
## Summary
- fix Postgres startup on packaged builds by resolving resource path
- adjust packaging so postgres directory only copied once

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'pandas')*
