### PR TITLE
Fix postgres path for packaged Electron app

### DIFF
--- a/electron-app/main.js
+++ b/electron-app/main.js
@@ -120,17 +120,49 @@ function createWindow () {
 
 function startPostgres() {
   const platform = process.platform;
-  // expected postgres binaries under electron-app/postgres/<platform>/bin
-  const binDir = path.join(__dirname, 'postgres', platform, 'bin');
+  const searchDirs = [];
+
+  if (app.isPackaged) {
+    // In packaged apps the postgres folder is bundled as an extraResource
+    searchDirs.push(path.join(process.resourcesPath, 'app', 'postgres', platform, 'bin'));
+    searchDirs.push(path.join(process.resourcesPath, 'postgres', platform, 'bin'));
+  }
+
+  // Development fallback
+  searchDirs.push(path.join(__dirname, 'postgres', platform, 'bin'));
+
+  let binDir = null;
+  for (const dir of searchDirs) {
+    if (fs.existsSync(dir)) {
+      binDir = dir;
+      break;
+    }
+  }
+
+  if (!binDir) {
+    console.error('PostgreSQL binaries not found in any of:', searchDirs);
+    return null;
+  }
+
   const pgPath = path.join(binDir, platform === 'win32' ? 'postgres.exe' : 'postgres');
   const initdbPath = path.join(binDir, platform === 'win32' ? 'initdb.exe' : 'initdb');
   const dataDir = path.join(app.getPath('userData'), 'postgres-data');
+
+  if (!fs.existsSync(pgPath)) {
+    console.error('postgres executable not found:', pgPath);
+    return null;
+  }
 
   if (!fs.existsSync(path.join(dataDir, 'PG_VERSION'))) {
     spawnSync(initdbPath, ['-D', dataDir]);
   }
 
-  postgresProcess = spawn(pgPath, ['-D', dataDir, '-p', '55432']);
+  try {
+    postgresProcess = spawn(pgPath, ['-D', dataDir, '-p', '55432']);
+  } catch (err) {
+    console.error('Failed to spawn postgres:', err);
+    return null;
+  }
 
   postgresProcess.stdout.on('data', (data) => {
     console.log(`postgres: ${data}`);
@@ -138,6 +170,10 @@ function startPostgres() {
 
   postgresProcess.stderr.on('data', (data) => {
     console.error(`postgres err: ${data}`);
+  });
+
+  postgresProcess.on('error', (err) => {
+    console.error('postgres process error:', err);
   });
 
   return postgresProcess;


### PR DESCRIPTION
## Summary
- fix Postgres startup paths and handle missing binaries gracefully

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'pandas')*
