### PR TITLE
Fix: Improve Electron app portability and backend stability

### DIFF
--- a/electron-app/TROUBLESHOOTING_GUIDE.md
+++ b/electron-app/TROUBLESHOOTING_GUIDE.md
@@ -1,0 +1,88 @@
+# Theseus Insight Electron App Troubleshooting Guide
+
+This guide provides information on common issues related to the packaged Theseus Insight Electron application, the fixes that have been implemented, and how to diagnose further problems.
+
+## Summary of Issues Addressed
+
+The primary challenges with distributing the Electron app, particularly on macOS, were related to:
+
+1.  **Python Interpreter Path:** The application was using hardcoded paths to a specific user's Conda Python environment. This would cause the Python backend to fail on any other machine.
+2.  **Python Dependency Loading:** Even if a system Python was found, it might not correctly locate and load the Python dependencies (`psycopg2`, `uvicorn`, `fastapi`, etc.) that are bundled with the application.
+3.  **PostgreSQL Dynamic Libraries (macOS):** Packaged macOS applications require careful handling of dynamic library (`.dylib`) paths. The bundled PostgreSQL instance has several internal libraries and dependencies. If their paths are absolute or point to locations on the build machine, PostgreSQL will fail to start on another Mac. This is a common issue with Electron's `asar` packaging and macOS Gatekeeper/notarization.
+
+## Implemented Fixes
+
+To address these issues, the following changes were made:
+
+### 1. Python Environment and Backend Startup (`main.js`)
+
+*   **Removed Hardcoded Python Paths:** The Electron main process (`main.js`) no longer searches for Python in hardcoded Conda environments (e.g., `/Users/c/...`).
+*   **Dynamic Python Detection:** It now attempts to find `python3` in the system's PATH. If not found, it falls back to `python`. An error is logged if neither is found.
+*   **`PYTHONPATH` Configuration:**
+    *   The `python_deps` directory (located at `YourApp.app/Contents/Resources/app/python_deps/` in the packaged app) is now explicitly added to the `PYTHONPATH` environment variable when launching the Python backend.
+    *   The `projectRoot` (i.e., `YourApp.app/Contents/Resources/app/`) is also included in `PYTHONPATH` to ensure the backend's own modules (e.g., `theseus_insight`) are discoverable.
+    *   This helps the Python interpreter locate all necessary bundled libraries.
+
+### 2. Python Backend Scripts (`start_backend.py`, `start_backend_robust.py`)
+
+*   **`sys.path` Modification:** Both Python backend startup scripts now explicitly add the `python_deps` directory to `sys.path` at runtime. This provides an additional layer of robustness, ensuring the bundled dependencies are discoverable even if `PYTHONPATH` inheritance has issues.
+
+### 3. PostgreSQL Pathing on macOS (`scripts/afterPack.js`)
+
+*   **Enhanced `afterPack` Script:** This script runs during the `electron-builder` packaging process for macOS.
+    *   It uses `install_name_tool` to correct the internal paths of PostgreSQL's dynamic libraries (`.dylib` files) and executables.
+    *   Hardcoded paths from the build machine (e.g., `/Users/builder/...` or absolute paths into the app bundle itself) are changed to be relative to the executables (`@loader_path/../lib/yourlibrary.dylib`).
+    *   The script now has more detailed logging of its operations and a more comprehensive verification step that checks key PostgreSQL binaries (`postgres`, `initdb`, `psql`, `pg_ctl`) for any remaining problematic library paths.
+
+## Debugging Further Issues
+
+If the application still freezes or fails to start correctly on a new machine (especially after re-signing on macOS), here are some steps to diagnose the problem:
+
+### 1. Electron Main Process Logs (Developer Console)
+
+*   **How to Open:** In the Electron app, you can usually open the Developer Tools by navigating to `View > Toggle Developer Tools` in the application menu (if available), or by using a shortcut like `Option+Command+I` (macOS) or `Ctrl+Shift+I` (Windows/Linux).
+*   **What to Look For:**
+    *   Errors related to starting the Python backend.
+    *   Messages from `main.js` about the Python command (`pythonCmd`) or `PYTHONPATH`.
+    *   Errors from the PostgreSQL startup process.
+    *   Any "Uncaught Exception" or "Unhandled Rejection" messages.
+    *   Output from the `afterPack.js` script will be visible in the terminal during the build process, not in the app's console.
+
+### 2. Python Backend Logs
+
+*   The `main.js` script is configured to print the `stdout` and `stderr` from the Python backend process to its own console. These messages will appear in the Electron Developer Console (see above).
+*   Look for:
+    *   Python tracebacks (error messages).
+    *   "DEBUG" messages from `start_backend.py` or `start_backend_robust.py` showing the paths being used (e.g., `app_root`, `python_deps_path`).
+    *   Messages from `uvicorn` about the FastAPI server starting up or failing.
+    *   Errors related to database connections (e.g., from `psycopg2`).
+
+### 3. Verifying PostgreSQL Library Paths (macOS)
+
+If you suspect PostgreSQL pathing issues on macOS, even after the `afterPack.js` script has run:
+
+*   **Locate the App:** Find your packaged `.app` bundle (e.g., `Theseus Insight.app`).
+*   **Find PostgreSQL Binaries:** The key PostgreSQL executables are typically located in:
+    `Theseus Insight.app/Contents/Resources/app/postgres/darwin/bin/`
+*   **Use `otool`:** Open a Terminal and use the `otool -L` command to inspect a binary. For example:
+    ```bash
+    otool -L "/path/to/Theseus Insight.app/Contents/Resources/app/postgres/darwin/bin/postgres"
+    ```
+*   **What to Look For:**
+    *   Each line after the first one is a linked dynamic library.
+    *   **Correct paths** start with:
+        *   `@loader_path/...` (meaning relative to the executable)
+        *   `/usr/lib/...` (system libraries)
+        *   `/System/Library/...` (system libraries)
+    *   **Problematic paths** might look like:
+        *   `/Users/your_build_user/...` (absolute path from the build machine)
+        *   An absolute path pointing back into the `.../postgres/darwin/lib/` directory inside the app bundle (e.g., `/Applications/Theseus Insight.app/Contents/Resources/app/postgres/darwin/lib/libpq.5.dylib` instead of `@loader_path/../lib/libpq.5.dylib`).
+*   The `afterPack.js` script logs its verification results during the build process. Review these logs first.
+
+### 4. Re-Signing on macOS
+
+*   If you are re-signing the application (e.g., with a different certificate), ensure the signing process preserves ad-hoc signatures of internal executables and doesn't break the corrected dylib paths.
+*   Use the `--deep` flag with `codesign` carefully, as it can sometimes be problematic. It's often better to sign files individually from the inside out if you encounter issues.
+*   Verify entitlements are correct.
+
+By following these steps, you should be able to gather more information about why the application might be failing on a different machine.

--- a/electron-app/main.js
+++ b/electron-app/main.js
@@ -661,36 +661,33 @@ function startBackend() {
   
   console.log(`Project root: ${projectRoot}`);
   console.log(`Is packaged: ${isPackaged}`);
-  
-  // Try to detect conda environment
-  let pythonCmd = 'python';
-  let condaEnvPath = null;
-  
-  // Common conda installation paths
-  const condaPaths = [
-    '/Users/c/miniforge3/envs/theseus/bin/python',
-    '/Users/c/anaconda3/envs/theseus/bin/python',
-    '/Users/c/miniconda3/envs/theseus/bin/python',
-    '/opt/homebrew/anaconda3/envs/theseus/bin/python'
-  ];
-  
-  // Check if CONDA_PREFIX is set (user has activated environment)
-  if (process.env.CONDA_PREFIX && fs.existsSync(path.join(process.env.CONDA_PREFIX, 'bin', 'python'))) {
-    condaEnvPath = path.join(process.env.CONDA_PREFIX, 'bin', 'python');
-    pythonCmd = condaEnvPath;
-  } else {
-    // Try common paths
-    for (const condaPath of condaPaths) {
-      if (fs.existsSync(condaPath)) {
-        condaEnvPath = condaPath;
-        pythonCmd = condaPath;
-        break;
+
+  function findPythonCommand() {
+    try {
+      spawnSync('python3', ['--version']);
+      return 'python3';
+    } catch (e) {
+      try {
+        spawnSync('python', ['--version']);
+        return 'python';
+      } catch (e2) {
+        console.error('Neither python3 nor python found in PATH.');
+        return null; // Or handle error appropriately
       }
     }
   }
-  
+
+  let pythonCmd = findPythonCommand();
+
+  if (!pythonCmd) {
+    console.error('No Python interpreter found. The backend cannot be started.');
+    // Optionally, you could show an error dialog to the user or quit the app
+    // For now, just log the error and the backend won't start.
+    return;
+  }
+
   console.log(`Using Python interpreter: ${pythonCmd}`);
-  
+
   // Choose the startup method based on packaging
   let startupArgs;
   if (isPackaged) {
@@ -725,6 +722,12 @@ function startBackend() {
   
   console.log(`Startup args: ${startupArgs.join(' ')}`);
   
+  const pythonDepsPath = path.join(projectRoot, 'python_deps');
+  const pythonPathParts = [projectRoot, pythonDepsPath];
+  if (process.env.PYTHONPATH) {
+    pythonPathParts.push(process.env.PYTHONPATH);
+  }
+
   pythonProcess = spawn(pythonCmd, startupArgs, {
     cwd: projectRoot,  // Set working directory to project root
     env: {
@@ -732,12 +735,9 @@ function startBackend() {
       DATABASE_URL: 'postgresql://theseus:theseus@localhost:55432/theseusdb',
       ELECTRON_IS_PACKAGED: isPackaged ? 'true' : 'false',
       ELECTRON_RESOURCES_PATH: isPackaged ? process.resourcesPath : '',
-      // Add conda environment paths if detected
-      PATH: condaEnvPath ? 
-        `${path.dirname(condaEnvPath)}:${process.env.PATH}` : 
-        process.env.PATH,
-      CONDA_DEFAULT_ENV: 'theseus',
-      PYTHONPATH: projectRoot
+      PATH: process.env.PATH,
+      CONDA_DEFAULT_ENV: 'theseus', // This might be irrelevant now but harmless
+      PYTHONPATH: pythonPathParts.join(path.delimiter)
     }
   });
 

--- a/electron-app/scripts/afterPack.js
+++ b/electron-app/scripts/afterPack.js
@@ -3,6 +3,7 @@ const path = require('path');
 const { execSync } = require('child_process');
 
 exports.default = async function(context) {
+  console.log('--- Starting afterPack script for PostgreSQL macOS dylib fixing ---');
   console.log('🔧 Running afterPack hook...');
   
   const { electronPlatformName, appOutDir } = context;
@@ -80,6 +81,7 @@ exports.default = async function(context) {
             console.log(`    New: ${newPath}`);
             
             try {
+              console.log(`    Executing: install_name_tool -change "${libraryPath}" "${newPath}" "${binaryPath}"`);
               execSync(`install_name_tool -change "${libraryPath}" "${newPath}" "${binaryPath}"`, { stdio: 'pipe' });
               hasChanges = true;
             } catch (error) {
@@ -105,6 +107,7 @@ exports.default = async function(context) {
     
     try {
       console.log(`  🔄 Setting library ID for ${libName}`);
+      console.log(`    Executing: install_name_tool -id "${newId}" "${libPath}"`);
       execSync(`install_name_tool -id "${newId}" "${libPath}"`, { stdio: 'pipe' });
       console.log(`  ✅ ${libName}: Library ID updated`);
     } catch (error) {
@@ -150,50 +153,59 @@ exports.default = async function(context) {
   }
   
   // Enhanced verification with more detailed output
-  console.log('🔍 Verifying fixes...');
-  try {
-    const testBinary = path.join(binDir, 'initdb');
-    if (fs.existsSync(testBinary)) {
-      const verifyOutput = execSync(`otool -L "${testBinary}"`, { encoding: 'utf8' });
-      const allLines = verifyOutput.split('\n').filter(line => line.trim());
-      
-      console.log(`🔍 Checking ${path.basename(testBinary)} dependencies:`);
-      allLines.forEach(line => {
-        const trimmed = line.trim();
-        // Skip the binary itself (first line) and empty lines
-        if (trimmed && !trimmed.startsWith(testBinary) && !trimmed.endsWith(':')) {
-          const isProblematic = (trimmed.includes('/Users/') || 
-                                trimmed.includes('TheseusInsight') || 
-                                (trimmed.includes('postgres') && trimmed.startsWith('/') && !trimmed.startsWith('/@')));
-          console.log(`  ${isProblematic ? '❌' : '✅'} ${trimmed}`);
-        }
-      });
-      
-      // Only check dependency lines, not the binary header line
-      const dependencyLines = allLines.filter(line => {
-        const trimmed = line.trim();
-        return trimmed && 
-               !trimmed.startsWith(testBinary) && 
-               !trimmed.endsWith(':') &&
-               trimmed.includes('.dylib');
-      });
-      
-      const badPaths = dependencyLines.filter(line => {
-        return line.includes('/Users/') || 
-               line.includes('TheseusInsight') || 
-               (line.includes('postgres') && line.trim().startsWith('/') && !line.includes('@'));
-      });
-      
-      if (badPaths.length === 0) {
-        console.log('✅ Verification passed: No hardcoded paths found');
-      } else {
-        console.log('❌ Warning: Some hardcoded paths remain:');
-        badPaths.forEach(badPath => console.log(`  ${badPath.trim()}`));
-      }
+  console.log('🔍 Verifying fixes for key binaries...');
+  const keyBinaries = ['initdb', 'postgres', 'psql', 'pg_ctl'];
+  let totalProblematicPaths = 0;
+
+  for (const binaryName of keyBinaries) {
+    const binaryPath = path.join(binDir, binaryName);
+    if (!fs.existsSync(binaryPath)) {
+      console.log(`  ⚠️  Skipping verification for ${binaryName}: File not found at ${binaryPath}`);
+      continue;
     }
-  } catch (error) {
-    console.log(`⚠️  Could not verify fixes: ${error.message}`);
+
+    console.log(`🔍 Verifying library paths for: ${binaryName}`);
+    try {
+      const otoolOutput = execSync(`otool -L "${binaryPath}"`, { encoding: 'utf8' });
+      const lines = otoolOutput.split('\n');
+      
+      // First line is the binary itself, skip it.
+      // Subsequent lines are dependencies.
+      for (let i = 1; i < lines.length; i++) {
+        const line = lines[i].trim();
+        if (line === '' || line.includes('(compatibility version')) {
+          continue;
+        }
+
+        const dependencyPath = line.split(' ')[0]; // Get the path part
+        let status = '❓'; // Default to potentially problematic
+
+        if (dependencyPath.startsWith('/usr/lib/') || dependencyPath.startsWith('/System/')) {
+          status = '✅'; // System path
+        } else if (dependencyPath.startsWith('@loader_path/')) {
+          status = '✅'; // Loader relative
+        } else if (dependencyPath.startsWith('@rpath/')) {
+          status = '✅'; // Rpath based
+        } else if (dependencyPath.includes('/Users/') ||
+                   (dependencyPath.startsWith('/') && dependencyPath.includes('postgres/darwin/lib')) ||
+                   (dependencyPath.startsWith('/') && dependencyPath.includes('postgres/darwin/bin'))) {
+          status = '❌'; // Clearly problematic (build machine path or absolute bundled path)
+          totalProblematicPaths++;
+        }
+        console.log(`  ${status} ${dependencyPath}`);
+      }
+    } catch (error) {
+      console.log(`  ⚠️  Error verifying ${binaryName}: ${error.message}`);
+      totalProblematicPaths++; // Count error in verification as problematic
+    }
+  }
+
+  if (totalProblematicPaths === 0) {
+    console.log('✅ Overall Verification Passed: No problematic paths found in key binaries.');
+  } else {
+    console.log(`❌ Overall Verification Warning: Found ${totalProblematicPaths} problematic path(s) across key binaries.`);
   }
   
   console.log('🎉 PostgreSQL path fixing completed');
+  console.log('--- Finished afterPack script for PostgreSQL macOS dylib fixing ---');
 }; 

--- a/electron-app/start_backend.py
+++ b/electron-app/start_backend.py
@@ -40,6 +40,16 @@ def setup_packaged_environment():
     
     print(f"DEBUG: App root: {app_root}")
     print(f"DEBUG: App root exists: {os.path.exists(app_root)}")
+
+    # Add bundled Python dependencies to Python path
+    python_deps_path = os.path.join(app_root, 'python_deps')
+    if os.path.exists(python_deps_path):
+        print(f"DEBUG: Found bundled Python dependencies: {python_deps_path}")
+        if python_deps_path not in sys.path:
+            sys.path.insert(0, python_deps_path)
+        print(f"DEBUG: Added to sys.path: {python_deps_path}")
+    else:
+        print(f"DEBUG: Bundled Python dependencies not found: {python_deps_path}")
     
     # Set environment variables for config file locations
     config_dir = os.path.join(app_root, 'config')


### PR DESCRIPTION
This commit addresses several issues that caused the Electron application to fail when you run it on machines other than the build environment, particularly on macOS.

Key changes:

1.  **Python Environment in `main.js`:**
    *   Removed hardcoded Conda paths for Python interpreter lookup.
    *   Implemented dynamic detection of `python3` or `python` from the system PATH.
    *   Ensured the bundled `python_deps` directory is correctly added to `PYTHONPATH` for the backend process, allowing it to find its dependencies.

2.  **Python Backend Scripts (`start_backend.py`, `start_backend_robust.py`):**
    *   Modified/verified that both scripts add the `python_deps` directory to `sys.path` at runtime, providing an additional layer of robustness for dependency discovery.

3.  **PostgreSQL Pathing on macOS (`scripts/afterPack.js`):**
    *   Enhanced the `afterPack.js` script with more detailed logging of its `install_name_tool` operations.
    *   Improved the verification step to check more PostgreSQL binaries (postgres, psql, pg_ctl, initdb) and provide clearer feedback on whether dylib paths are correct or problematic.

4.  **Troubleshooting Guide:**
    *   Added `electron-app/TROUBLESHOOTING_GUIDE.md` to explain the problems, the implemented solutions, and provide guidance for diagnosing future issues.

These changes aim to make the packaged Electron application more portable by ensuring the Python backend can start reliably and that PostgreSQL's dynamic libraries are correctly pathed on macOS.