### PR TITLE
Fix Postgres hardcoded path in electron build script

### DIFF
--- a/electron-app/POSTGRES_PATH_FIX.md
+++ b/electron-app/POSTGRES_PATH_FIX.md
@@ -1,0 +1,22 @@
+# Postgres Path Fix
+
+## Issue
+The universal build script `scripts/fix-postgres.js` contained a hard coded
+path to the developer's machine:
+```
+/Users/c/software_projects/TheseusInsight/electron-app/postgres/darwin/lib/libpq.5.dylib
+```
+When the Electron app was built, this absolute path was embedded in the binary
+patching step. The resulting application worked only on the original machine but
+failed on others when PostgreSQL was accessed.
+
+## Fix
+The script now resolves the path to `libpq.5.dylib` relative to the packaged
+`.app` directory instead of using a fixed absolute path. During the patching
+process each PostgreSQL binary is scanned for any reference to
+`libpq.5.dylib`.  Regardless of what absolute path the build process embedded,
+those references are rewritten to `@rpath/libpq.5.dylib` and an rpath of
+`@loader_path/../lib` is added if required.
+
+This ensures that the packaged application uses only relative paths to its own
+resources, allowing it to run on any Mac after signing.

--- a/electron-app/scripts/fix-postgres.js
+++ b/electron-app/scripts/fix-postgres.js
@@ -1,19 +1,44 @@
 const { execSync } = require("child_process");
 const path = require("path");
 
-module.exports = async ctx => {
-  const app = path.join(ctx.appOutDir, "Theseus Insight.app");
-  const lib = path.join(app, "Contents/Resources/app/postgres/darwin/lib");
-  const bin = path.join(app, "Contents/Resources/app/postgres/darwin/bin");
+module.exports = async (ctx) => {
+  // Resolve the built .app directory using the product name
+  const appName = ctx.packager.appInfo.productFilename || "Theseus Insight";
+  const app = path.join(ctx.appOutDir, `${appName}.app`);
 
-  execSync(`install_name_tool -id @rpath/libpq.5.dylib "${lib}/libpq.5.dylib"`);
+  const libDir = path.join(app, "Contents/Resources/app/postgres/darwin/lib");
+  const binDir = path.join(app, "Contents/Resources/app/postgres/darwin/bin");
+  const libpqPath = path.join(libDir, "libpq.5.dylib");
 
-  execSync(`find "${bin}" -type f -perm +111`, { encoding: "utf8" })
-    .trim().split("\n").forEach(f => {
-      execSync(`install_name_tool -change \
-/Users/c/software_projects/TheseusInsight/electron-app/postgres/darwin/lib/libpq.5.dylib \
-@rpath/libpq.5.dylib "${f}"`);
-      try { execSync(`install_name_tool -add_rpath @loader_path/../lib "${f}"`); }
-      catch {/* rpath already exists */}
+  // Ensure libpq itself uses an rpath-based ID
+  execSync(`install_name_tool -id @rpath/libpq.5.dylib "${libpqPath}"`);
+
+  // Get list of executable files under postgres/bin
+  const binFiles = execSync(`find "${binDir}" -type f -perm +111`, {
+    encoding: "utf8",
+  })
+    .trim()
+    .split("\n");
+
+  binFiles.forEach((file) => {
+    // Inspect current library references to find any path containing libpq.5.dylib
+    const deps = execSync(`otool -L "${file}"`, { encoding: "utf8" })
+      .split("\n")
+      .map((line) => line.trim().split(" ")[0])
+      .filter((line) => line.includes("libpq.5.dylib") && !line.startsWith("@rpath"));
+
+    deps.forEach((oldPath) => {
+      try {
+        execSync(`install_name_tool -change "${oldPath}" @rpath/libpq.5.dylib "${file}"`);
+      } catch {
+        // ignore if install_name_tool fails for a given path
+      }
     });
+
+    try {
+      execSync(`install_name_tool -add_rpath @loader_path/../lib "${file}"`);
+    } catch {
+      // rpath may already exist; ignore errors
+    }
+  });
 };


### PR DESCRIPTION
## Summary
- fix absolute path in `scripts/fix-postgres.js`
- document the issue in `POSTGRES_PATH_FIX.md`

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'pandas')*

------
https://chatgpt.com/codex/tasks/task_e_683a40dcc06483329bb7c78d89119f34