### PR TITLE
Prevent duplicate paper imports by title

### DIFF
--- a/theseus_insight/data_model/data_handling.py
+++ b/theseus_insight/data_model/data_handling.py
@@ -153,6 +153,13 @@ class PaperDatabase:
             count = cursor.fetchone()[0]
             return count > 0
 
+    def paper_exists_by_title(self, title: str) -> bool:
+        """Check if a paper with the given title already exists in the database."""
+        with self.get_cursor() as cursor:
+            cursor.execute('SELECT COUNT(*) FROM papers WHERE title = ?', (title,))
+            count = cursor.fetchone()[0]
+            return count > 0
+
     def get_paper_by_url(self, url: str) -> dict | None:
         """Get paper details by URL if it exists."""
         with self.get_cursor() as cursor:

--- a/theseus_insight/utils/db_migration/db_import.py
+++ b/theseus_insight/utils/db_migration/db_import.py
@@ -109,9 +109,23 @@ class DatabaseImporter:
             papers_data = json.load(f)
         
         stats = {"total": len(papers_data), "imported": 0, "skipped": 0, "errors": 0}
-        
+
+        seen_titles = set()
+        seen_urls = set()
+
         for i, paper_data in enumerate(papers_data):
             try:
+                # Skip if paper exists by title or URL in DB or has appeared earlier in this import
+                if skip_duplicates:
+                    if (
+                        self.db.paper_exists_by_url(paper_data["url"]) or
+                        self.db.paper_exists_by_title(paper_data["title"]) or
+                        paper_data["url"] in seen_urls or
+                        paper_data["title"] in seen_titles
+                    ):
+                        stats["skipped"] += 1
+                        continue
+
                 # Create Paper object
                 paper = Paper(
                     title=paper_data["title"],
@@ -127,6 +141,9 @@ class DatabaseImporter:
                     embedding=paper_data.get("embedding")
                 )
                 
+                seen_titles.add(paper_data["title"])
+                seen_urls.add(paper_data["url"])
+
                 # Insert paper (with duplicate handling)
                 was_inserted = self.db.insert_paper(paper, skip_duplicates=skip_duplicates)
                 


### PR DESCRIPTION
## Summary
- add a `paper_exists_by_title` helper in `PaperDatabase`
- expand importer to skip papers whose title or URL already exists

## Testing
- `python -m py_compile theseus_insight/data_model/data_handling.py theseus_insight/utils/db_migration/db_import.py`

------
https://chatgpt.com/codex/tasks/task_e_683b0ade7b088332b68bd468deb45888