### PR TITLE
Fix circular import in utils package

### DIFF
--- a/theseus_insight/utils/__init__.py
+++ b/theseus_insight/utils/__init__.py
@@ -1,6 +1,7 @@
-# Utils package for Theseus Insight 
-from .backfill_embeddings import *
+"""Utility functions and tools for Theseus Insight."""
+
 from .common_utils import *
 
 # Database migration tools
 from .db_migration import DatabaseExporter, DatabaseImporter, DatabaseMigrator
+


### PR DESCRIPTION
## Summary
- adjust `theseus_insight/utils/__init__.py` to avoid importing `backfill_embeddings`
- this resolves an import cycle when importing `PaperDatabase`

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'pandas')*

------
https://chatgpt.com/codex/tasks/task_e_683b1440de908332a2428d99200d1d7d