### PR TITLE
Fix circular import with db_migration utilities

### DIFF
--- a/theseus_insight/utils/__init__.py
+++ b/theseus_insight/utils/__init__.py
@@ -1,6 +1,11 @@
-# Utils package for Theseus Insight 
-from .backfill_embeddings import *
-from .common_utils import *
+"""Utility functions and helpers for Theseus Insight."""
 
-# Database migration tools
-from .db_migration import DatabaseExporter, DatabaseImporter, DatabaseMigrator
+from .common_utils import *  # noqa: F401,F403 -- re-export for convenience
+
+# NOTE: Database migration helpers are intentionally not imported here to
+# avoid pulling in heavy dependencies and creating circular imports when the
+# data model loads ``theseus_insight.utils``.  Import directly from
+# ``theseus_insight.utils.db_migration`` when needed.
+
+__all__ = [name for name in globals() if not name.startswith("_")]
+


### PR DESCRIPTION
## Summary
- adjust `theseus_insight/utils/__init__.py` so it no longer imports `db_migration`
- this avoids a circular dependency when loading `PaperDatabase`

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'pandas')*


------
https://chatgpt.com/codex/tasks/task_e_683b1440de908332a2428d99200d1d7d