### PR TITLE
Update README for SQLite transition

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,8 +15,6 @@ Theseus Insight is an end‑to‑end platform for analysing research papers and 
 - [Environment Variables](#environment-variables)
 - [Running the API](#running-the-api)
 - [Running the Frontend](#running-the-frontend)
-- [External Database Access](#external-database-access)
-- [External Database Access](#external-database-access)
 - [Custom Data Storage Location](#custom-data-storage-location)
 - [Desktop Build](#desktop-build)
 - [Key Endpoints](#key-endpoints)
@@ -176,82 +174,10 @@ During development use the Vite dev server as shown in the [Quickstart](#quickst
 
 ---
 
-## External Database Access
-
-By default, the PostgreSQL database runs in an isolated Docker container and is not accessible from external tools. For development, debugging, data migration, or administrative tasks, you can enable external database access.
-
-### Enabling External Access
-
-**Option 1: Using the helper script (recommended)**
-```bash
-# Start with external database access enabled
-./scripts/start-with-db-access.sh
-
-# Or pass additional docker-compose arguments
-./scripts/start-with-db-access.sh -d  # Run in detached mode
-```
-
-**Option 2: Manual Docker Compose override**
-```bash
-# Start with both compose files
-docker-compose -f docker-compose.yml -f docker-compose.db-external.yml up --build
-```
-
-**Option 3: Environment variable in .env file**
-```bash
-# Add to your .env file
-ALLOW_DB_CONNECTION=true
-
-# Then start normally (this sets the variable but you still need the override file)
-docker-compose -f docker-compose.yml -f docker-compose.db-external.yml up --build
-```
-
-### Connection Details
-
-When external access is enabled, the database is accessible on:
-- **Host**: `localhost`
-- **Port**: `5433` (to avoid conflicts with local PostgreSQL)
-- **Database**: `theseusdb`
-- **Username**: `theseus`
-- **Password**: `theseus`
-
-### Example Connections
-
-**Using psql command line:**
-```bash
-psql -h localhost -p 5433 -U theseus -d theseusdb
-```
-
-**Using pgAdmin:**
-- Server: `localhost:5433`
-- Maintenance database: `theseusdb`
-- Username: `theseus`
-- Password: `theseus`
-
-**Using Python/SQLAlchemy:**
-```python
-from sqlalchemy import create_engine
-engine = create_engine("postgresql://theseus:theseus@localhost:5433/theseusdb")
-```
-
-### Security Considerations
-
-⚠️ **Important**: Only enable external database access in development environments or secure networks. When enabled:
-- The database accepts connections from any IP address on the host machine
-- Database credentials are transmitted over the network
-- The database port is exposed on the host machine
-
-For production deployments, use secure connection methods such as:
-- VPN tunnels
-- SSH port forwarding
-- Database connection pools with authentication
-- Network firewalls and access controls
-
----
 
 ## Custom Data Storage Location
 
-By default, Theseus Insight stores data in the local `./data` directory and uses Docker named volumes for the PostgreSQL database. For installations with limited internal storage, you can redirect all data to an external drive or custom location.
+By default, Theseus Insight stores data in the local `./data` directory. This folder contains the `theseus.db` SQLite database alongside generated newsletters, podcasts and other files. For installations with limited internal storage, you can redirect all data to an external drive or custom location.
 
 ### Quick Setup for External Storage
 
@@ -296,11 +222,7 @@ When using external storage, the following directory structure is created:
 │   ├── podcasts/               # Generated podcast audio/video
 │   ├── visualizations/         # Generated visualizations
 │   └── temp/                   # Temporary processing files
-└── postgres_data/              # PostgreSQL database files
-    ├── base/                   # Database tables and indexes
-    ├── global/                 # Cluster-wide data
-    ├── pg_wal/                 # Write-ahead log files
-    └── ...                     # Other PostgreSQL system files
+└── theseus.db                 # SQLite database file
 ```
 
 ### Platform-Specific Paths
@@ -345,13 +267,10 @@ If you've already been running Theseus Insight and want to move existing data to
 docker-compose down
 
 # Create external storage directory
-mkdir -p /Volumes/nyx/theseus_insight_data/{app_data,postgres_data}
+mkdir -p /Volumes/nyx/theseus_insight_data/app_data
 
 # Copy existing application data
 cp -r ./data/* /Volumes/nyx/theseus_insight_data/app_data/
-
-# Export existing database (if you have data)
-docker run --rm -v theseusinsight_theseus_db_data:/data -v /Volumes/nyx/theseus_insight_data/postgres_data:/backup alpine sh -c "cp -r /data/* /backup/"
 
 # Start with external storage
 ./scripts/start-with-external-storage.sh
@@ -411,13 +330,13 @@ docker run --rm -v theseusinsight_theseus_db_data:/data -v /Volumes/nyx/theseus_
 Theseus Insight features advanced hybrid search capabilities that combine the precision of BM25-style keyword ranking with the contextual understanding of semantic similarity. This provides significantly enhanced search accuracy compared to traditional keyword-only or semantic-only approaches.
 
 **Key Features:**
-- **BM25-Enhanced Keyword Search**: Uses PostgreSQL's full-text search with `ts_rank_cd()` for sophisticated term frequency and document ranking (replaces simple substring matching)
+- **BM25-Enhanced Keyword Search**: Uses SQLite FTS5 with the `bm25()` ranking function for accurate term frequency scoring
 - **Dual-Mode Search**: Simultaneously performs semantic similarity using vector embeddings and advanced keyword ranking across paper titles and abstracts
 - **Weighted Title Boost**: Title matches receive 2x scoring weight compared to abstract matches for improved relevance
 - **Weighted Scoring**: User-adjustable weights for combining semantic and keyword scores (default: 60% semantic, 40% keyword)
 - **Real-Time Scoring**: Returns individual `semantic_score`, `keyword_score`, and combined `hybrid_score` for transparency
 - **Full Integration**: Works seamlessly with existing filters (date range, score threshold, pagination)
-- **Performance Optimized**: Database-level operations using PostgreSQL with pgvector and GIN indexes for scalable performance
+- **Performance Optimized**: Database-level operations use sqlite-vec for vector search and FTS5 indexes for scalable performance
 
 **Example API Request:**
 ```json
@@ -459,10 +378,10 @@ POST /api/papers/hybrid-search
 The React interface provides an intuitive toggle for enabling hybrid search with interactive weight adjustment sliders. Users can fine-tune the balance between semantic understanding and BM25-style keyword ranking to optimize results for their specific research needs.
 
 **Technical Implementation:**
-- **PostgreSQL Full-Text Search**: Leverages native `tsvector` and `tsquery` types with English language stemming and stopword filtering
-- **Ranking Algorithm**: Uses `ts_rank_cd()` with normalization flags for document length and term frequency weighting
-- **Index Optimization**: GIN (Generalized Inverted Index) indexes on title, abstract, and combined search vectors for fast retrieval
-- **Automatic Migration**: Existing installations automatically gain BM25 capabilities through database schema updates
+- **SQLite Full-Text Search**: Utilises the FTS5 module with Unicode-aware tokenization and stopword filtering
+- **Ranking Algorithm**: Uses the `bm25()` ranking function for weighted relevance
+- **Index Optimization**: FTS5 indexes provide fast lookup over title and abstract text
+- **Automatic Migration**: Existing installations automatically update the SQLite schema when new search features are introduced
 
 See [docs/embedding_functionality_README.md](docs/embedding_functionality_README.md) for more details.
 ### Theseus Insight Run Orchestration
@@ -498,22 +417,22 @@ Theseus Insight includes comprehensive database migration tools for transferring
 **Export database to archive:**
 ```bash
 python -m theseus_insight.utils.db_migration.db_migrate export \
-    --source-db "postgresql://user:pass@localhost:5432/theseus_dev" \
+    --source-db data/theseus.db \
     --output ./backup.tar.gz
 ```
 
 **Import archive to new database:**
 ```bash
 python -m theseus_insight.utils.db_migration.db_migrate import \
-    --target-db "postgresql://user:pass@new-server:5432/theseus_prod" \
+    --target-db data/theseus.db \
     --input ./backup.tar.gz
 ```
 
 **Direct migration with verification:**
 ```bash
 python -m theseus_insight.utils.db_migration.db_migrate migrate \
-    --source-db "postgresql://user:pass@old-server:5432/theseus_dev" \
-    --target-db "postgresql://user:pass@new-server:5432/theseus_prod" \
+    --source-db old.db \
+    --target-db new.db \
     --verify
 ```
 
@@ -531,8 +450,8 @@ For detailed documentation and advanced usage examples, see [`theseus_insight/do
 ## Desktop Build
 
 An Electron wrapper is provided in the `electron-app` directory. It bundles the
-Python backend and a PostgreSQL database using `pgvector`. PostgreSQL runs on
-port **55432** to avoid conflicts with existing installations.
+Python backend together with the built SQLite database so no separate database
+server is required.
 
 ### Building
 
@@ -561,7 +480,7 @@ This project is licensed under the [Apache License 2.0](LICENSE) unless otherwis
 - [Docling](https://github.com/doclingjs/docling) for document parsing.
 - [pydub](https://github.com/jiaaro/pydub) for audio processing.
 - [Amazon Polly](https://aws.amazon.com/polly/), [OpenAI TTS](https://platform.openai.com/docs/) for text-to-speech.
-- [FastAPI](https://fastapi.tiangolo.com/), [Pydantic](https://pydantic-docs.helpmanual.io/), [PostgreSQL](https://www.postgresql.org/) with [pgvector](https://github.com/pgvector/pgvector) for backend processing.
+- [FastAPI](https://fastapi.tiangolo.com/), [Pydantic](https://pydantic-docs.helpmanual.io/), SQLite with [sqlite-vec](https://github.com/asg017/sqlite-vss) for backend processing.
 
 Theseus Insight is maintained by [M. Chimiste](https://github.com/M-Chimiste) & contributors.
 

--- a/docs/db_migration_README.md
+++ b/docs/db_migration_README.md
@@ -167,16 +167,14 @@ backup.tar.gz
 
 ## Database Connection Strings
 
-The tools support standard PostgreSQL connection strings:
+The tools accept standard SQLite file paths or connection URLs:
 
 ```bash
-# Basic format
-postgresql://username:password@hostname:port/database
+# Local file path
+data/theseus.db
 
-# Examples
-postgresql://theseus:secret@localhost:5432/theseus_dev
-postgresql://user@localhost/theseus_db
-postgresql://user:pass@prod-server.com:5432/theseus_production
+# URL style
+sqlite:///data/theseus.db
 ```
 
 ## Error Handling
@@ -283,9 +281,8 @@ python -m theseus_insight.utils.db_migration.db_migrate migrate \
 ## Version Compatibility
 
 - Export format version: 1.0
-- Compatible with PostgreSQL 12+
 - Requires Python 3.8+
-- Dependencies: psycopg, pgvector, pydantic
+- Dependencies: sqlite3, pydantic
 
 ## Support
 

--- a/docs/db_spec.md
+++ b/docs/db_spec.md
@@ -1,6 +1,6 @@
 # Theseus Insight - Database Specification v1.0
 
-> PostgreSQL schema (with pgvector) created automatically by `PaperDatabase._initialize_db()` during application start-up
+> SQLite schema (with sqlite-vec) created automatically by `PaperDatabase._initialize_db()` during application start-up
 
 ---
 
@@ -22,11 +22,11 @@ Database access is configured via the `DATABASE_URL` environment variable.
 
 | Property             | Default value                                                                                                                                                    | Notes                                                  |
 | -------------------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------- | ------------------------------------------------------ |
-| **Engine**           | PostgreSQL + pgvector |
-|                          | Requires running Postgres server |
-| **Connection string**| `postgresql://theseus:theseus@localhost:5432/theseusdb` |
+| **Engine**           | SQLite + sqlite-vec |
+|                          | Single file database (`theseus.db`) |
+| **Connection string**| `data/theseus.db` |
 |                          | Provided via `DATABASE_URL` environment variable |
-| **Connection model** | One connection per CRUD call using `psycopg` |
+| **Connection model** | Uses Python's builtin `sqlite3` |
 ---
 
 ## 3. Entity-Relationship Overview
@@ -182,8 +182,8 @@ WHERE p.name = 'openai';
 
 ## 6. Performance & Indexing Notes
 
-* Primary keys automatically create B-tree indexes in PostgreSQL.
-* Full-text search vectors are indexed with `GIN`.
+* Primary keys automatically create B-tree indexes in SQLite.
+* Full-text search vectors are indexed with FTS5.
 * The composite `UNIQUE(provider_id, name)` on `models` also yields an index.
 * Add B-tree indexes on `date` or `score` if query latency grows:
 

--- a/docs/embedding_functionality_README.md
+++ b/docs/embedding_functionality_README.md
@@ -1,6 +1,6 @@
 # Embedding Functionality for Semantic Search
 
-This document describes the new vector embedding functionality added to Theseus Insight, enabling semantic similarity search using pgvector with PostgreSQL.
+This document describes the vector embedding functionality added to Theseus Insight, enabling semantic similarity search using sqlite-vec with SQLite.
 
 ## Overview
 
@@ -10,7 +10,7 @@ The system now stores vector embeddings of paper abstracts in the database, allo
 
 ### 1. Automatic Embedding Generation
 - When papers are processed through the main pipeline, their abstracts are automatically embedded using the configured embedding model
-- Embeddings are stored as vectors in the PostgreSQL database using the pgvector extension
+- Embeddings are stored as vectors in the SQLite database using the sqlite-vec extension
 
 ### 2. Similarity Search API
 New API endpoints for semantic search:
@@ -84,7 +84,7 @@ Finds papers similar to an existing paper using its stored embedding.
 The `papers` table now includes:
 - `embedding VECTOR` - Stores the vector embedding of the paper's abstract
 - Updated `fetch_all_papers()` to include embeddings
-- New similarity search methods using pgvector's cosine distance operator (`<=>`)
+- New similarity search methods using sqlite-vec cosine distance functions
 
 ### 4. Data Model Updates
 
@@ -142,9 +142,9 @@ python -m theseus_insight.utils.backfill_embeddings --batch-size 5
 ## Technical Details
 
 ### Vector Storage
-- Uses PostgreSQL's pgvector extension for efficient vector storage and similarity search
-- Embeddings are stored as VECTOR type columns
-- Cosine similarity is calculated using the `<=>` operator
+- Uses the sqlite-vec extension for efficient vector storage and similarity search
+- Embeddings are stored as BLOB columns compatible with sqlite-vec
+- Cosine similarity is calculated using sqlite-vec functions
 
 ### Similarity Calculation
 - Uses cosine distance: `embedding <=> query_embedding`
@@ -175,7 +175,7 @@ python -m theseus_insight.utils.backfill_embeddings --batch-size 5
 - Embedding generation adds processing time to the paper analysis pipeline
 - Consider the embedding model size vs. performance trade-off
 - Use appropriate batch sizes for backfilling large numbers of papers
-- pgvector provides efficient indexing for similarity searches
+- sqlite-vec provides efficient indexing for similarity searches
 
 ## Future Enhancements
 

--- a/docs/hybrid_search_functionality_README.md
+++ b/docs/hybrid_search_functionality_README.md
@@ -2,21 +2,15 @@
 
 ## Overview
 
-We have successfully upgraded Theseus Insight's hybrid search capabilities from simple substring matching to a sophisticated BM25-style ranking system using PostgreSQL's full-text search functionality. This provides dramatically improved keyword search relevance while maintaining the powerful semantic similarity capabilities.
+We have successfully upgraded Theseus Insight's hybrid search capabilities from simple substring matching to a sophisticated BM25-style ranking system using SQLite's FTS5 module. This provides dramatically improved keyword search relevance while maintaining the powerful semantic similarity capabilities.
 
 ## What Was Implemented
 
 ### 1. Database Schema Enhancements
 
-**New Columns Added:**
-- `search_vector` (tsvector) - Combined title + abstract for general search
-- `title_vector` (tsvector) - Title-only search vector
-- `abstract_vector` (tsvector) - Abstract-only search vector
-
-**Indexes Created:**
-- `papers_search_vector_idx` - GIN index on search_vector
-- `papers_title_vector_idx` - GIN index on title_vector  
-- `papers_abstract_vector_idx` - GIN index on abstract_vector
+**New FTS Table:**
+- `papers_fts` (virtual table) mirrors title and abstract
+- Triggers keep the FTS table synchronized with the main `papers` table
 
 ### 2. Enhanced Keyword Scoring Algorithm
 
@@ -27,13 +21,7 @@ CASE WHEN (LOWER(title) LIKE %s OR LOWER(abstract) LIKE %s) THEN 1 ELSE 0 END
 
 **After (BM25-style ranking):**
 ```sql
-COALESCE(
-    GREATEST(
-        ts_rank_cd(p.search_vector, plainto_tsquery('english', %s), 32),
-        ts_rank_cd(p.title_vector, plainto_tsquery('english', %s), 32) * 2.0,
-        ts_rank_cd(p.abstract_vector, plainto_tsquery('english', %s), 32)
-    ), 0.0
-) as keyword_score
+bm25(papers_fts, 1.0, 2.0) AS keyword_score
 ```
 
 ### 3. Key Improvements
@@ -52,12 +40,12 @@ COALESCE(
 ### 4. Automatic Migration System
 
 **Migration Script:** `theseus_insight/utils/update_search_vectors.py`
-- Safely adds new columns to existing installations
-- Populates search vectors for all existing papers
+- Creates the FTS5 virtual table if missing
+- Backfills FTS entries for all existing papers
 - Handles edge cases and provides detailed progress reporting
 
-**Auto-Population:** New papers automatically get search vectors on insertion
-- Updated `insert_paper()` method includes tsvector generation
+**Auto-Population:** New papers automatically get FTS entries on insertion
+- Updated `insert_paper()` method maintains the FTS table
 - No manual intervention required for new data
 
 ## Performance Benefits
@@ -69,7 +57,7 @@ COALESCE(
 - **Weighted Fields**: Title matches prioritized over abstract matches
 
 ### 2. Database Performance
-- **GIN Indexes**: Fast full-text search without table scans
+- **FTS5 Indexes**: Fast full-text search without table scans
 - **Optimized Queries**: Single query vs multiple LIKE operations
 - **Scalability**: Performance stays consistent as database grows
 
@@ -114,11 +102,11 @@ COALESCE(
 
 ## Technical Architecture
 
-### PostgreSQL Full-Text Search Stack
-1. **tsvector**: Preprocessed, indexed document representation
-2. **tsquery**: Query parsing with operators (&, |, !, phrase matching)
-3. **ts_rank_cd()**: Ranking function with normalization options
-4. **GIN Indexes**: Inverted index structure for fast lookups
+### SQLite FTS5 Search Stack
+1. **FTS5 table**: Virtual table storing tokenized title and abstract
+2. **MATCH queries**: Standard FTS5 query syntax with operators and phrase matching
+3. **bm25()**: Built-in ranking function with adjustable weights
+4. **FTS5 indexes**: Inverted indexes for fast lookups
 
 ### Integration Points
 - **Database Layer**: `hybrid_search_papers()` method in `data_handling.py`
@@ -145,7 +133,7 @@ COALESCE(
 1. Automatic migration occurs on next API startup
 2. Run `python -m theseus_insight.utils.update_search_vectors` to verify migration
 3. No downtime required - migration is additive only
-4. Rollback possible by dropping the new tsvector columns if needed
+4. Rollback possible by dropping the FTS table if needed (it will be rebuilt automatically)
 
 **For New Installations:**
 - Full BM25 functionality available immediately
@@ -156,4 +144,4 @@ COALESCE(
 
 This enhancement represents a significant improvement in search quality while maintaining full backward compatibility. The BM25-style keyword ranking provides more nuanced and relevant results, especially for complex multi-term queries, while the existing semantic similarity capabilities remain unchanged.
 
-The implementation leverages PostgreSQL's mature full-text search capabilities, ensuring both performance and reliability at scale. 
+The implementation leverages SQLite's FTS5 module together with sqlite-vec, ensuring both performance and reliability at scale.


### PR DESCRIPTION
## Summary
- remove old PostgreSQL instructions
- document SQLite database usage and update hybrid search details
- streamline external storage steps and desktop build info
- update credits for sqlite-vec
- revise DB spec and doc files for SQLite

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'pandas')*

------
https://chatgpt.com/codex/tasks/task_e_683b1037f3b083328a4c0b1e9d311a3b