### PR TITLE
Add progress bar for database export

### DIFF
--- a/theseus-ui/src/pages/Settings.tsx
+++ b/theseus-ui/src/pages/Settings.tsx
@@ -95,6 +95,7 @@ const Settings: React.FC = () => {
   const [importProgress, setImportProgress] = useState<number>(0);
   const [importStatus, setImportStatus] = useState<string>('');
   const [isImporting, setIsImporting] = useState<boolean>(false);
+  const [exportProgress, setExportProgress] = useState<number>(0);
 
   const { data: orchestrationConfig, isLoading: isLoadingOrchestration, isError: isErrorOrchestration } = useQuery({
     queryKey: ['orchestrationConfig'],
@@ -187,9 +188,13 @@ const Settings: React.FC = () => {
   });
 
   const exportDatabaseMutation = useMutation({
-    mutationFn: () => settingsApi.exportDatabase(),
+    mutationFn: () => settingsApi.exportDatabase((p) => setExportProgress(p)),
+    onMutate: () => {
+      setExportProgress(0);
+    },
     onSuccess: (response) => {
       try {
+        setExportProgress(100);
         // Validate response data
         if (!response.data || response.data.size === 0) {
           throw new Error('Export file is empty or corrupt');
@@ -843,9 +848,23 @@ const Settings: React.FC = () => {
                 {exportDatabaseMutation.isPending ? 'Exporting...' : 'Export Database'}
               </Button>
               {exportDatabaseMutation.isPending && (
-                <Typography variant="caption" color="text.secondary" sx={{ mt: 1, display: 'block' }}>
-                  This may take a few minutes for large databases...
-                </Typography>
+                <Box sx={{ mt: 2 }}>
+                  <Box sx={{ display: 'flex', alignItems: 'center', gap: 1 }}>
+                    <Box sx={{ width: '100%' }}>
+                      <LinearProgress
+                        variant="determinate"
+                        value={exportProgress}
+                        sx={{ height: 8, borderRadius: 4 }}
+                      />
+                    </Box>
+                    <Typography variant="body2" color="text.secondary">
+                      {exportProgress}%
+                    </Typography>
+                  </Box>
+                  <Typography variant="caption" color="text.secondary" sx={{ mt: 1, display: 'block' }}>
+                    This may take a few minutes for large databases...
+                  </Typography>
+                </Box>
               )}
             </Box>
 

--- a/theseus-ui/src/services/api.ts
+++ b/theseus-ui/src/services/api.ts
@@ -28,7 +28,16 @@ export const settingsApi = {
   getModels: () => api.get('/models'),
   runNewsletterPipeline: (params: any) => api.post('/actions/run-newsletter-pipeline', params),
   abortTask: (taskId: string) => api.post(`/tasks/${taskId}/abort`),
-  exportDatabase: () => api.get('/settings/database/export', { responseType: 'blob' }),
+  exportDatabase: (onProgress?: (percent: number) => void) =>
+    api.get('/settings/database/export', {
+      responseType: 'blob',
+      onDownloadProgress: (event: ProgressEvent) => {
+        if (onProgress && event.total) {
+          const percent = Math.round((event.loaded * 100) / event.total);
+          onProgress(percent);
+        }
+      },
+    }),
   importDatabase: (file: File, importMode: 'merge' | 'overwrite' = 'merge') => {
     const formData = new FormData();
     formData.append('backup_file', file);


### PR DESCRIPTION
## Summary
- show progress when exporting the database
- support download progress in API client

## Testing
- `pytest -q`
- `npm run lint` *(fails: Cannot find package '@eslint/js')*
- `npm run build` *(fails: missing dependencies)*

------
https://chatgpt.com/codex/tasks/task_e_683b663c9c9083328fe4d1445acfdc6b