### PR TITLE
Add configurable token limit for research context

### DIFF
--- a/theseus-ui/src/pages/Settings.tsx
+++ b/theseus-ui/src/pages/Settings.tsx
@@ -713,6 +713,7 @@ const Settings: React.FC = () => {
     const initialSearchQueryCount = config.initial_search_query_count || 3;
     const localSearchLimit = config.local_search_limit || 10;
     const externalSearchLimit = config.external_search_limit || 5;
+    const maxContextTokens = config.max_context_tokens || 30000;
 
     return (
       <Box sx={{ display: 'flex', flexDirection: 'column', gap: 3 }}>
@@ -1300,6 +1301,14 @@ const Settings: React.FC = () => {
                 onChange={e => handleModelConfigChange('research_agent_model_config', 'external_search_limit', Number(e.target.value))}
                 helperText="Papers per external search"
                 inputProps={{ min: 1, max: 20 }}
+              />
+              <TextField
+                label="Max Context Tokens"
+                type="number"
+                value={maxContextTokens}
+                onChange={e => handleModelConfigChange('research_agent_model_config', 'max_context_tokens', Number(e.target.value))}
+                helperText="Token limit for research context"
+                inputProps={{ min: 1000, max: 200000 }}
               />
             </Box>
           </CardContent>

--- a/theseus_insight/agentic_research/graph_configuration.py
+++ b/theseus_insight/agentic_research/graph_configuration.py
@@ -74,6 +74,11 @@ class AgentConfiguration(BaseModel):
         metadata={"description": "Delay in seconds between sequential external searches to avoid overwhelming APIs."},
     )
 
+    max_context_tokens: int = Field(
+        default=30000,
+        metadata={"description": "Maximum tokens allowed when building paper context"},
+    )
+
     @classmethod
     def from_runnable_config(
         cls, config: Optional[RunnableConfig] = None

--- a/theseus_insight/agentic_research/research_graph.py
+++ b/theseus_insight/agentic_research/research_graph.py
@@ -3,6 +3,7 @@
 import logging
 from pathlib import Path
 from typing import List, Dict, Any, Optional, AsyncGenerator
+import tiktoken
 
 from langchain_core.messages import AIMessage, HumanMessage, BaseMessage
 from langchain_core.runnables import RunnableConfig
@@ -722,8 +723,15 @@ IMPORTANT: Generate search queries that are effective for finding relevant paper
             # Create paper contexts for outline generation
             paper_contexts = []
             historical_contexts = []
-            
-            for source in judged_sources:
+
+            # Sort papers by relevance_score descending
+            sorted_sources = sorted(judged_sources, key=lambda s: s.get("relevance_score", 0), reverse=True)
+
+            encoding = tiktoken.get_encoding("cl100k_base")
+            token_budget = configurable.max_context_tokens
+            token_count = 0
+
+            for source in sorted_sources:
                 # Build paper context
                 context_parts = []
                 if source.get("title"):
@@ -740,14 +748,19 @@ IMPORTANT: Generate search queries that are effective for finding relevant paper
                 
                 paper_context = "\n".join(context_parts)
                 if paper_context.strip():
+                    ctx_tokens = len(encoding.encode(paper_context))
+                    if token_count + ctx_tokens > token_budget:
+                        break
+                    token_count += ctx_tokens
                     paper_contexts.append(paper_context)
-                    
+
                     # Also add to historical context if it's a significant paper
                     if source.get("relevance_score", 0) >= 8:
                         historical_contexts.append(f"{source.get('year', 'Unknown')} - {source.get('title', 'Unknown')}")
             
             # Combine paper contexts for outline generation
-            combined_paper_context = "\n\n---\n\n".join(paper_contexts[:10])  # Limit to avoid token overflow
+            # Paper contexts are already truncated based on token budget
+            combined_paper_context = "\n\n---\n\n".join(paper_contexts)
             historical_context = "; ".join(historical_contexts[:5])  # Key papers only
             
             if not combined_paper_context.strip():
@@ -1459,6 +1472,13 @@ IMPORTANT: Generate search queries that are effective for finding relevant paper
                     research_insights = traditional_insights
             else:
                 research_insights = "\n\n---\n\n".join(enhanced_insights) if enhanced_insights else ""
+
+            # Truncate research insights to respect token budget
+            encoding = tiktoken.get_encoding("cl100k_base")
+            insight_tokens = encoding.encode(research_insights)
+            if len(insight_tokens) > configurable.max_context_tokens:
+                insight_tokens = insight_tokens[:configurable.max_context_tokens]
+                research_insights = encoding.decode(insight_tokens)
             
             # Check if we have access to full text papers - this is key for quality
             full_text_count = 0

--- a/theseus_insight/agentic_research/unified_model_router.py
+++ b/theseus_insight/agentic_research/unified_model_router.py
@@ -129,6 +129,7 @@ class UnifiedModelRouter:
             "initial_search_query_count": 3,
             "local_search_limit": 10,
             "external_search_limit": 5,
+            "max_context_tokens": 30000,
             "search_config": {
                 "semantic_weight": 0.6,
                 "keyword_weight": 0.4,

--- a/theseus_insight/api/models.py
+++ b/theseus_insight/api/models.py
@@ -331,6 +331,10 @@ class ResearchAgentModelConfigApi(BaseModel):
     local_search_limit: Optional[int] = Field(10, ge=1, le=50, description="Papers per local search operation")
     external_search_limit: Optional[int] = Field(5, ge=1, le=20, description="Papers per external search operation")
     external_search_delay: Optional[float] = Field(2.0, ge=1.0, le=10.0, description="Delay between external API calls (ArXiv requires minimum 2 seconds)")
+
+    # Maximum tokens for paper context in outline/summary generation
+    max_context_tokens: Optional[int] = Field(30000, ge=1000, le=200000,
+        description="Maximum number of tokens to include when building the research context")
     
     # Search strategy configuration
     search_config: Optional[Dict[str, Any]] = Field(
@@ -358,6 +362,7 @@ class ResearchAgentModelConfigApi(BaseModel):
                 "initial_search_query_count": 3,
                 "local_search_limit": 10,
                 "external_search_limit": 5,
+                "max_context_tokens": 30000,
                 "search_config": {
                     "semantic_weight": 0.6,
                     "keyword_weight": 0.4,


### PR DESCRIPTION
## Summary
- add `max_context_tokens` to research agent model config and defaults
- expose token setting in Settings UI
- respect token budget when compiling paper contexts and research summaries

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'pandas')*

------
https://chatgpt.com/codex/tasks/task_e_68479013e17083329c9f8b5c7270b2e4