### PR TITLE
Add CSV export for similar papers list

### DIFF
--- a/theseus-ui/src/pages/SimilarityView.tsx
+++ b/theseus-ui/src/pages/SimilarityView.tsx
@@ -8,11 +8,14 @@ import {
   FormControl,
   InputLabel,
   Select,
-  MenuItem
+  MenuItem,
+  Tooltip,
+  Button
 } from '@mui/material';
 import type { SelectChangeEvent } from '@mui/material';
 import ArrowBackIcon from '@mui/icons-material/ArrowBack';
 import CloseIcon from '@mui/icons-material/Close';
+import DownloadIcon from '@mui/icons-material/Download';
 import { papersApi } from '../services/api';
 import type { PaperApiResponse, SimilarPapersResponse } from '../services/api';
 import PaperRowCard from './PaperRowCard';
@@ -75,6 +78,78 @@ const SimilarityView: React.FC<SimilarityViewProps> = ({ referencePaper, onClose
     // fetchSimilarPapers will be called automatically due to the useEffect dependency on limit
   };
 
+  // Export similar papers to CSV
+  const handleExportCSV = () => {
+    // Helper to escape CSV values (handle commas, quotes, newlines)
+    const escapeCSV = (value: string): string => {
+      if (value.includes(',') || value.includes('"') || value.includes('\n')) {
+        return `"${value.replace(/"/g, '""')}"`;
+      }
+      return value;
+    };
+
+    // Format date for display
+    const formatDate = (dateStr: string): string => {
+      try {
+        const date = new Date(dateStr);
+        return date.toLocaleDateString('en-US', { 
+          year: 'numeric', 
+          month: 'short', 
+          day: 'numeric' 
+        });
+      } catch {
+        return dateStr;
+      }
+    };
+
+    // Build CSV content
+    const headers = ['Title', 'Published Date', 'URL', 'Similarity Score'];
+    const rows: string[][] = [];
+
+    // Add seed paper as first row
+    rows.push([
+      escapeCSV(referencePaper.title),
+      escapeCSV(formatDate(referencePaper.date)),
+      referencePaper.url,
+      'Seed Paper'
+    ]);
+
+    // Add similar papers
+    similarPapers.forEach((paper) => {
+      const similarityPercent = `${((paper.similarity_score ?? 0) * 100).toFixed(1)}%`;
+      rows.push([
+        escapeCSV(paper.title),
+        escapeCSV(formatDate(paper.date)),
+        paper.url,
+        similarityPercent
+      ]);
+    });
+
+    // Combine headers and rows
+    const csvContent = [
+      headers.join(','),
+      ...rows.map(row => row.join(','))
+    ].join('\n');
+
+    // Create and trigger download
+    const blob = new Blob([csvContent], { type: 'text/csv;charset=utf-8;' });
+    const url = URL.createObjectURL(blob);
+    const link = document.createElement('a');
+    link.href = url;
+    
+    // Create filename from reference paper title (sanitized)
+    const sanitizedTitle = referencePaper.title
+      .replace(/[^a-zA-Z0-9\s]/g, '')
+      .replace(/\s+/g, '_')
+      .substring(0, 50);
+    link.download = `similar_papers_${sanitizedTitle}.csv`;
+    
+    document.body.appendChild(link);
+    link.click();
+    document.body.removeChild(link);
+    URL.revokeObjectURL(url);
+  };
+
   if (loading && similarPapers.length === 0) {
     return (
       <Box sx={{ display: 'flex', justifyContent: 'center', alignItems: 'center', height: '80vh' }}>
@@ -122,6 +197,18 @@ const SimilarityView: React.FC<SimilarityViewProps> = ({ referencePaper, onClose
               <MenuItem value={200}>200</MenuItem>
             </Select>
           </FormControl>
+          <Tooltip title="Export to CSV">
+            <Button
+              variant="outlined"
+              size="small"
+              startIcon={<DownloadIcon />}
+              onClick={handleExportCSV}
+              disabled={loading || similarPapers.length === 0}
+              sx={{ textTransform: 'none' }}
+            >
+              Export
+            </Button>
+          </Tooltip>
           <Box sx={{ display: 'flex' }}>
             <IconButton onClick={onClose} aria-label="back to papers" size="small">
               <ArrowBackIcon />


### PR DESCRIPTION
This pull request adds an "Export to CSV" feature in the `SimilarityView` component, allowing users to download the list of similar papers (including the seed paper) as a CSV file. The export includes proper formatting and escaping for CSV values, and the button is integrated into the UI with appropriate icons and tooltips.

**Feature Addition: Export to CSV**
- Added a `handleExportCSV` function to `SimilarityView` that generates a CSV file containing the seed paper and all similar papers, with formatted dates and escaped values for CSV compatibility. The filename is dynamically generated from the reference paper's title.
- Integrated a new "Export" button (with tooltip and download icon) into the controls, which triggers the CSV export. The button is disabled while loading or if there are no similar papers.

**UI and Dependency Updates**
- Imported `Tooltip`, `Button`, and `DownloadIcon` from Material UI to support the new export functionality and improve the UI.Introduces a button to export the reference and similar papers as a CSV file in the SimilarityView. The export includes title, published date, URL, and similarity score, with proper formatting and escaping for CSV compatibility.