### PR TITLE
Dev

### DIFF
--- a/config/orchestration.json
+++ b/config/orchestration.json
@@ -11,7 +11,7 @@
     "gpu_offload": null
   },
   "judge_model": {
-    "model_name": "granite-4.0-h-tiny-mlx",
+    "model_name": "ibm/granite-4-h-tiny",
     "model_type": "lmstudio",
     "max_new_tokens": 512,
     "temperature": 0.1,

--- a/docker-compose.db-external.yml
+++ b/docker-compose.db-external.yml
@@ -29,6 +29,11 @@ services:
       - ./scripts/009_add_lmstudio_multi_server.sql:/app/sql/009_add_lmstudio_multi_server.sql
       - ./scripts/010_add_per_server_model_config.sql:/app/sql/010_add_per_server_model_config.sql
       - ./scripts/011_newsletter_multi_server.sql:/app/sql/011_newsletter_multi_server.sql
+      - ./scripts/012_timeline_indexes.sql:/app/sql/012_timeline_indexes.sql
+      - ./scripts/013_profile_interest_metrics.sql:/app/sql/013_profile_interest_metrics.sql
+      - ./scripts/014_interest_short_labels.sql:/app/sql/014_interest_short_labels.sql
+      - ./scripts/015_profile_star_map.sql:/app/sql/015_profile_star_map.sql
+      - ./scripts/016_profile_star_map_3d.sql:/app/sql/016_profile_star_map_3d.sql
       # Mount migration tracking files
       - ./scripts/create_migration_tracking.sql:/app/sql/create_migration_tracking.sql
       - ./scripts/check_and_apply_migrations.sh:/app/sql/check_and_apply_migrations.sh 

--- a/docker-compose.external-storage.yml
+++ b/docker-compose.external-storage.yml
@@ -34,6 +34,11 @@ services:
       - ./scripts/009_add_lmstudio_multi_server.sql:/app/sql/009_add_lmstudio_multi_server.sql
       - ./scripts/010_add_per_server_model_config.sql:/app/sql/010_add_per_server_model_config.sql
       - ./scripts/011_newsletter_multi_server.sql:/app/sql/011_newsletter_multi_server.sql
+      - ./scripts/012_timeline_indexes.sql:/app/sql/012_timeline_indexes.sql
+      - ./scripts/013_profile_interest_metrics.sql:/app/sql/013_profile_interest_metrics.sql
+      - ./scripts/014_interest_short_labels.sql:/app/sql/014_interest_short_labels.sql
+      - ./scripts/015_profile_star_map.sql:/app/sql/015_profile_star_map.sql
+      - ./scripts/016_profile_star_map_3d.sql:/app/sql/016_profile_star_map_3d.sql
       # Mount migration tracking files
       - ./scripts/create_migration_tracking.sql:/app/sql/create_migration_tracking.sql
       - ./scripts/check_and_apply_migrations.sh:/app/sql/check_and_apply_migrations.sh

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -64,6 +64,11 @@ services:
       - ./scripts/009_add_lmstudio_multi_server.sql:/app/sql/009_add_lmstudio_multi_server.sql
       - ./scripts/010_add_per_server_model_config.sql:/app/sql/010_add_per_server_model_config.sql
       - ./scripts/011_newsletter_multi_server.sql:/app/sql/011_newsletter_multi_server.sql
+      - ./scripts/012_timeline_indexes.sql:/app/sql/012_timeline_indexes.sql
+      - ./scripts/013_profile_interest_metrics.sql:/app/sql/013_profile_interest_metrics.sql
+      - ./scripts/014_interest_short_labels.sql:/app/sql/014_interest_short_labels.sql
+      - ./scripts/015_profile_star_map.sql:/app/sql/015_profile_star_map.sql
+      - ./scripts/016_profile_star_map_3d.sql:/app/sql/016_profile_star_map_3d.sql
       # Mount migration tracking files
       - ./scripts/create_migration_tracking.sql:/app/sql/create_migration_tracking.sql
       - ./scripts/check_and_apply_migrations.sh:/app/sql/check_and_apply_migrations.sh

--- a/requirements.txt
+++ b/requirements.txt
@@ -28,7 +28,7 @@ yake
 # LLM & AI Services
 # LLMFactory - Unified inference interface for multiple providers
 # v0.2.4 includes LM Studio singleton handling fix
-git+https://github.com/M-Chimiste/LLMFactory.git@v0.2.4
+git+https://github.com/M-Chimiste/LLMFactory.git
 anthropic[bedrock]
 openai
 ollama

--- a/setup.py
+++ b/setup.py
@@ -12,7 +12,7 @@ with req_path.open() as f:
 
 setup(
     name="theseus-insight",
-    version="1.0.0",
+    version="1.0.1",
     packages=find_packages(),
     install_requires=requirements,
     python_requires=">=3.10",

--- a/theseus_insight/__init__.py
+++ b/theseus_insight/__init__.py
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-__version__ = "1.0.0"
+__version__ = "1.0.1"
 from .theseus_insight import *
 from .prompt import *
 from .podcast import *

--- a/theseus_insight/api/routers/logs.py
+++ b/theseus_insight/api/routers/logs.py
@@ -50,8 +50,8 @@ class TaskHistoryEntry(BaseModel):
 @router.get("/logs", response_model=List[LogEntry])
 async def get_logs_api(
     limit: int = Query(100, gt=0, le=1000),
-    from_date: Optional[str] = Query(None, regex="^\\d{4}-\\d{2}-\\d{2}$"), # YYYY-MM-DD
-    to_date: Optional[str] = Query(None, regex="^\\d{4}-\\d{2}-\\d{2}$") # YYYY-MM-DD
+    from_date: Optional[str] = Query(None, pattern=r"^\d{4}-\d{2}-\d{2}$"), # YYYY-MM-DD
+    to_date: Optional[str] = Query(None, pattern=r"^\d{4}-\d{2}-\d{2}$") # YYYY-MM-DD
 ):
     """
     Retrieves recent logs, filterable by date.
@@ -75,8 +75,8 @@ async def get_logs_api(
 @router.get("/task-history", response_model=List[TaskHistoryEntry])
 async def get_task_history_api(
     limit: int = Query(100, gt=0, le=1000),
-    from_date: Optional[str] = Query(None, regex="^\\d{4}-\\d{2}-\\d{2}$"), # YYYY-MM-DD
-    to_date: Optional[str] = Query(None, regex="^\\d{4}-\\d{2}-\\d{2}$") # YYYY-MM-DD
+    from_date: Optional[str] = Query(None, pattern=r"^\d{4}-\d{2}-\d{2}$"), # YYYY-MM-DD
+    to_date: Optional[str] = Query(None, pattern=r"^\d{4}-\d{2}-\d{2}$") # YYYY-MM-DD
 ):
     """
     Retrieves recent task history with complete information including task type.

--- a/theseus_insight/data_access/profiles.py
+++ b/theseus_insight/data_access/profiles.py
@@ -555,7 +555,7 @@ class ProfileInterestsRepository:
                 """
                 SELECT * FROM profile_research_interests 
                 WHERE profile_id = %s 
-                ORDER BY created_at
+                ORDER BY id
                 """,
                 (profile_id,)
             )

--- a/theseus_insight/data_access/trends.py
+++ b/theseus_insight/data_access/trends.py
@@ -1665,6 +1665,7 @@ class ProfileInterestMetricsRepository:
             # Create placeholders for profile IDs
             placeholders = ','.join(['%s'] * len(profile_ids))
 
+            # Note: Metrics are always stored with period_type='week' - aggregation happens in frontend
             cur.execute(f"""
                 WITH latest_metrics AS (
                     SELECT
@@ -1676,7 +1677,7 @@ class ProfileInterestMetricsRepository:
                         ROW_NUMBER() OVER (PARTITION BY pim.profile_interest_id ORDER BY pim.period_start DESC) as rn
                     FROM profile_interest_metrics pim
                     JOIN profile_research_interests pri ON pim.profile_interest_id = pri.id
-                    WHERE pim.period_type = %s
+                    WHERE pim.period_type = 'week'
                       AND pim.period_start >= %s
                       AND pri.profile_id IN ({placeholders})
                 ),
@@ -1707,7 +1708,7 @@ class ProfileInterestMetricsRepository:
                 WHERE pri.profile_id IN ({placeholders})
                 ORDER BY lm.growth_rate DESC NULLS LAST, lm.doc_count DESC NULLS LAST
                 LIMIT %s
-            """, (period_type, start_date, *profile_ids, *profile_ids, *profile_ids, limit))
+            """, (start_date, *profile_ids, *profile_ids, *profile_ids, limit))
 
             trending_interests = cur.fetchall()
 

--- a/theseus_insight/data_processing/newsletter_scorer.py
+++ b/theseus_insight/data_processing/newsletter_scorer.py
@@ -308,8 +308,8 @@ class NewsletterScorer:
                     papers_scored=completed
                 )
 
-                # NEW: Get per-server statistics
-                server_stats = NewsletterJobRepository.get_job_server_stats(job_id)
+                # Get per-server statistics from judge_task_queue (has better timestamps for throughput calc)
+                server_stats = JudgeTaskQueueRepository.get_job_server_stats(job_id)
 
                 stats_by_url = {}
                 for stat in (server_stats or []):
@@ -329,8 +329,10 @@ class NewsletterScorer:
                     avg_latency = None
                     throughput = 0.0
                     
+                    # Method 1 (preferred): Calculate from timestamps - accounts for parallel processing
                     first_task = stat.get('first_task_at')
-                    last_update = stat.get('last_update_at')
+                    # Support both column names from different sources
+                    last_update = stat.get('last_completed_at') or stat.get('last_update_at')
                     
                     if completed_tasks > 0 and first_task and last_update:
                         # Ensure timezone awareness compatibility if needed
@@ -342,7 +344,15 @@ class NewsletterScorer:
                         duration = (last_update - first_task).total_seconds()
                         if duration > 1.0:  # Avoid division by zero or tiny intervals
                             avg_latency = duration / completed_tasks
-                            throughput = (completed_tasks / duration) * 60
+                            throughput = (completed_tasks / duration) * 60  # Papers per minute
+                    
+                    # Method 2 (fallback): Use avg_task_duration_seconds 
+                    # Note: This assumes serial processing, so underestimates parallel throughput
+                    if throughput == 0.0:
+                        avg_duration = stat.get('avg_task_duration_seconds')
+                        if avg_duration and float(avg_duration) > 0:
+                            avg_latency = float(avg_duration)  # Convert Decimal to float
+                            throughput = 60.0 / avg_latency  # Papers per minute (serial estimate)
                     
                     return avg_latency, throughput
 

--- a/theseus_insight/data_processing/trends.py
+++ b/theseus_insight/data_processing/trends.py
@@ -316,7 +316,8 @@ class ProfileInterestProcessor:
             # Group papers by week
             weekly_data = defaultdict(list)
             for paper in papers:
-                pub_date = paper.get('published_date')
+                # Support both 'date' (from DB) and 'published_date' field names
+                pub_date = paper.get('date') or paper.get('published_date')
                 if pub_date:
                     if isinstance(pub_date, str):
                         pub_date = datetime.fromisoformat(pub_date.replace('Z', '+00:00')).date()

--- a/theseus_insight/workers/judge_worker.py
+++ b/theseus_insight/workers/judge_worker.py
@@ -23,6 +23,19 @@ from typing import Optional, List
 from uuid import UUID
 from datetime import datetime, timedelta
 
+
+class PaperProcessingError(Exception):
+    """
+    Exception for paper-specific errors that should NOT trigger the circuit breaker.
+    
+    Use this for errors related to the paper content (bad abstract, unparseable response, etc.)
+    rather than server-level errors (connection refused, timeout, server unavailable).
+    
+    Paper errors mark the task as failed but don't count toward consecutive_failures,
+    allowing the worker to continue processing other papers.
+    """
+    pass
+
 # Configure logging
 # Set up both console and file logging for worker diagnostics
 log_dir = os.path.join(os.path.dirname(os.path.dirname(os.path.dirname(__file__))), 'data', 'logs')
@@ -317,13 +330,38 @@ class JudgeWorker:
                     break
                 except Exception as e:
                     logger.error(f"Error in main loop: {e}", exc_info=True)
-                    self.consecutive_failures += 1
                     
-                    # With autocommit mode, no need to rollback
+                    # Determine if this is a server-level error that should trigger circuit breaker
+                    error_str = str(e).lower()
                     
-                    # If too many failures, exit
+                    # LM Studio "model not loaded" errors are transient - model may still be loaded
+                    # but LM Studio's API is temporarily reporting it as unavailable
+                    is_model_loading_error = any(term in error_str for term in [
+                        'no model found', 'nomodelmatchingquery', 'totalloadedmodels',
+                        'model not loaded', 'model unavailable', 'no model matching'
+                    ])
+                    
+                    # True server errors indicate the server itself is unreachable
+                    is_server_error = any(term in error_str for term in [
+                        'connection refused', 'timeout', 'unreachable',
+                        'network', 'socket', 'eof', 'reset', 'broken pipe', 'no route',
+                        'ssl', 'certificate', 'handshake', 'dns'
+                    ])
+                    
+                    if is_model_loading_error:
+                        # LM Studio model loading issue - retry but don't count toward circuit breaker
+                        # The model may still be loaded, just temporarily unavailable via API
+                        logger.warning(f"LM Studio model loading error (not counting toward circuit breaker): {e}")
+                    elif is_server_error:
+                        self.consecutive_failures += 1
+                        logger.warning(f"Server error in main loop, consecutive failures: {self.consecutive_failures}")
+                    else:
+                        # Other errors - log but don't count toward circuit breaker
+                        logger.info(f"Non-server error in main loop, not incrementing consecutive failures")
+                    
+                    # If too many server failures, exit
                     if self.consecutive_failures >= 10:
-                        logger.error("Too many consecutive failures, shutting down")
+                        logger.error("Too many consecutive server failures, shutting down")
                         break
                     
                     time.sleep(10)
@@ -569,11 +607,38 @@ class JudgeWorker:
             # Perform LLM scoring (this happens outside any transaction)
             logger.info(f"Scoring paper for {profile_name}")
             try:
+                # Check for empty/invalid abstract before sending to LLM
+                abstract = paper.get('abstract', '')
+                if not abstract or len(abstract.strip()) < 20:
+                    raise PaperProcessingError(f"Paper has empty or too-short abstract (length: {len(abstract.strip()) if abstract else 0})")
+                
                 score_data = self._score_paper(paper, research_interests)
+            except PaperProcessingError:
+                # Re-raise paper processing errors as-is
+                raise
+            except (TimeoutError, ConnectionError, OSError) as e:
+                # Server-level errors - re-raise to trigger circuit breaker logic
+                logger.error(f"Server error during LLM scoring: {e}")
+                raise
             except Exception as e:
-                # If LLM fails, mark the task as failed and continue
-                logger.error(f"LLM scoring failed: {e}")
-                raise Exception(f"LLM inference failed: {e}")
+                # Check if error indicates a paper content issue vs server issue
+                error_str = str(e).lower()
+                is_paper_issue = any(term in error_str for term in [
+                    'parse', 'json', 'decode', 'invalid', 'malformed', 'format',
+                    'content', 'empty', 'response', 'schema', 'validation'
+                ])
+                is_server_issue = any(term in error_str for term in [
+                    'connection', 'timeout', 'refused', 'unreachable', 'unavailable',
+                    'network', 'socket', 'model not', 'no model'
+                ])
+                
+                if is_paper_issue and not is_server_issue:
+                    # Paper content caused the error
+                    raise PaperProcessingError(f"Paper content caused LLM error: {e}")
+                else:
+                    # Assume server error, propagate normally
+                    logger.error(f"LLM scoring failed: {e}")
+                    raise
 
             # Create a new cursor for saving results
             cur = self.conn.cursor(row_factory=psycopg.rows.dict_row)
@@ -615,13 +680,60 @@ class JudgeWorker:
             self.tasks_processed += 1
             logger.info(f"Completed {job_type} task with score {score_data['score']} (total: {self.tasks_processed})")
 
+        except PaperProcessingError as e:
+            # Paper-level error (bad abstract, unparseable content, etc.)
+            # Do NOT re-raise - this allows the main loop to reset consecutive_failures
+            # But DO allow retries since LLM responses can be flaky
+            logger.warning(f"Task {task['id']} failed due to paper content issue: {e}")
+            
+            try:
+                if cur:
+                    cur.close()
+                with self.conn.cursor() as err_cur:
+                    # Get current attempts count
+                    err_cur.execute("SELECT attempts FROM judge_task_queue WHERE id = %s", (task['id'],))
+                    result = err_cur.fetchone()
+                    current_attempts = result[0] if result else 0
+                    new_attempts = current_attempts + 1
+                    
+                    # Use max_retries from config (default 3) - allow retries for LLM flakiness
+                    max_retries = getattr(self, 'max_retries', 3)
+                    
+                    if new_attempts < max_retries:
+                        # Requeue for retry - might work on another attempt (LLM flakiness)
+                        err_cur.execute("""
+                            UPDATE judge_task_queue
+                            SET status = 'pending',
+                                last_error = %s,
+                                attempts = %s,
+                                assigned_server_url = NULL,
+                                leased_until = NULL,
+                                leased_by_worker = NULL,
+                                updated_at = CURRENT_TIMESTAMP
+                            WHERE id = %s
+                        """, (f"Paper content issue (retrying): {e}", new_attempts, task['id']))
+                        logger.info(f"Task {task['id']} requeued for retry (attempt {new_attempts}/{max_retries}) - paper issue, may be LLM flakiness")
+                    else:
+                        # Max retries exceeded - mark as permanently failed
+                        err_cur.execute("""
+                            UPDATE judge_task_queue
+                            SET status = 'failed',
+                                last_error = %s,
+                                attempts = %s,
+                                updated_at = CURRENT_TIMESTAMP
+                            WHERE id = %s
+                        """, (f"Paper content error after {new_attempts} attempts: {e}", new_attempts, task['id']))
+                        logger.warning(f"Task {task['id']} permanently failed after {new_attempts} attempts (paper content issue)")
+            except Exception as retry_err:
+                logger.error(f"Failed to update task status: {retry_err}")
+            # Return normally - main loop will reset consecutive_failures (server is healthy)
+                
         except Exception as e:
+            # All other exceptions - mark task as failed and RE-RAISE to main loop
+            # This allows the main loop's circuit breaker to track failures properly
             logger.error(f"Task {task['id']} failed: {e}")
 
-            # Increment consecutive failures for circuit breaker
-            self.consecutive_failures += 1
-
-            # Mark task as failed with retry logic
+            # Mark task as failed with retry logic before re-raising
             try:
                 if cur:
                     cur.close()
@@ -636,7 +748,7 @@ class JudgeWorker:
                     max_retries = getattr(self, 'max_retries', 3)
                     
                     if new_attempts < max_retries:
-                        # Task has retries left - requeue as pending for another worker to try
+                        # Requeue for retry
                         err_cur.execute("""
                             UPDATE judge_task_queue
                             SET status = 'pending',
@@ -660,9 +772,11 @@ class JudgeWorker:
                             WHERE id = %s
                         """, (str(e), new_attempts, task['id']))
                         logger.warning(f"Task {task['id']} permanently failed after {new_attempts} attempts")
-                    # With autocommit mode, already committed
             except Exception as retry_err:
                 logger.error(f"Failed to update task status: {retry_err}")
+            
+            # Re-raise so main loop's circuit breaker can track this failure
+            raise
         finally:
             # Ensure cursor is closed
             if cur:

--- a/theseus_insight/workers/judge_worker.py
+++ b/theseus_insight/workers/judge_worker.py
@@ -374,9 +374,10 @@ class JudgeWorker:
         self.running = False
     
     def _watchdog_loop(self):
-        """Watch for stalls and dump stack traces to the log."""
+        """Watch for stalls and log a brief warning (full dumps written to file only)."""
         import traceback, sys
         stall_threshold = 45  # seconds without progress
+        stall_reported = False  # Only report once per stall
         while True:
             try:
                 time.sleep(15)
@@ -384,21 +385,23 @@ class JudgeWorker:
                     return
                 idle = time.time() - getattr(self, 'last_progress_ts', time.time())
                 if idle > stall_threshold:
-                    logger.error(f"Watchdog: worker stalled for {int(idle)}s. Dumping stack traces...")
-                    for thread_id, frame in sys._current_frames().items():
-                        stack = ''.join(traceback.format_stack(frame))
-                        logger.error(f"Thread {thread_id} stack:\n{stack}")
-                    # Also write a marker to the log file
-                    try:
-                        with open(self.log_file, 'a') as f:
-                            f.write(f"\n==== Watchdog dump at {time.strftime('%Y-%m-%d %H:%M:%S')} (idle {int(idle)}s) ====\n")
-                            for thread_id, frame in sys._current_frames().items():
-                                f.write(f"\n--- Thread {thread_id} ---\n")
-                                f.write(''.join(traceback.format_stack(frame)))
-                    except Exception:
-                        pass
-                    # Reset timer to avoid spamming
-                    self.last_progress_ts = time.time()
+                    if not stall_reported:
+                        # Log a brief warning (not the full stack traces)
+                        logger.warning(f"Watchdog: worker stalled for {int(idle)}s waiting for LLM response. Will recover after timeout.")
+                        stall_reported = True
+                        
+                        # Write detailed stack traces to file only (for debugging if needed)
+                        try:
+                            with open(self.log_file, 'a') as f:
+                                f.write(f"\n==== Watchdog dump at {time.strftime('%Y-%m-%d %H:%M:%S')} (idle {int(idle)}s) ====\n")
+                                for thread_id, frame in sys._current_frames().items():
+                                    f.write(f"\n--- Thread {thread_id} ---\n")
+                                    f.write(''.join(traceback.format_stack(frame)))
+                        except Exception:
+                            pass
+                else:
+                    # Worker is making progress - reset the stall flag
+                    stall_reported = False
             except Exception:
                 # Watchdog should never crash the worker
                 pass


### PR DESCRIPTION
This pull request introduces several improvements and fixes across the codebase, focusing on error handling for worker robustness, enhancements to monitoring and logging, and minor configuration and compatibility updates. The most significant changes are the introduction of fine-grained error handling in the judge worker, improved watchdog stall reporting, and updates to database migration scripts and model configuration.

**Worker error handling and robustness:**

* Added a new `PaperProcessingError` exception in `judge_worker.py` to distinguish between paper-specific errors and server-level errors, ensuring that only server errors affect the circuit breaker logic. Paper-specific errors (e.g., bad abstracts or unparseable responses) now mark tasks as failed without halting the worker. [[1]](diffhunk://#diff-8f456dfc1c2aa996aad86daeb5c87cad4366c37b4a8f816c68e04fbadae4d42eR26-R38) [[2]](diffhunk://#diff-8f456dfc1c2aa996aad86daeb5c87cad4366c37b4a8f816c68e04fbadae4d42eR613-R644) [[3]](diffhunk://#diff-8f456dfc1c2aa996aad86daeb5c87cad4366c37b4a8f816c68e04fbadae4d42eL320-R364)
* Enhanced server error handling in the main loop of `judge_worker.py` to differentiate between transient model loading issues, true server errors, and other exceptions, incrementing the circuit breaker only for actual server failures.

**Monitoring and logging improvements:**

* Modified the watchdog loop in `judge_worker.py` to log only a brief warning on stalls (instead of full stack traces), and write detailed stack traces to a file for debugging. This reduces log spam and improves clarity during LLM response delays. [[1]](diffhunk://#diff-8f456dfc1c2aa996aad86daeb5c87cad4366c37b4a8f816c68e04fbadae4d42eL339-R393) [[2]](diffhunk://#diff-8f456dfc1c2aa996aad86daeb5c87cad4366c37b4a8f816c68e04fbadae4d42eL362-R404)

**Database and configuration updates:**

* Added new SQL migration scripts for timeline indexes, profile interest metrics, short labels, and profile star map features to all relevant Docker Compose files, ensuring consistent database migrations across environments. [[1]](diffhunk://#diff-70082c1b4aa18a2ba4fa7a53fe8ad874abc6f5978c9c4832abe9fc343c78adf6R32-R36) [[2]](diffhunk://#diff-054d63b8445836a18969bbeb79a674c15e8b802d9c35dd3cc0a8de1ce364f72dR37-R41) [[3]](diffhunk://#diff-e45e45baeda1c1e73482975a664062aa56f20c03dd9d64a827aba57775bed0d3R67-R71)
* Updated the judge model configuration in `orchestration.json` to use the correct model name (`ibm/granite-4-h-tiny`).

**API and data access consistency:**

* Changed deprecated `regex` parameter to `pattern` in FastAPI `Query` definitions for date filtering, improving compatibility with recent FastAPI versions. [[1]](diffhunk://#diff-de4ec36687eb79eaeff0da0bc25f1b7f1964cce33612821d984c5f5f0f04e177L53-R54) [[2]](diffhunk://#diff-de4ec36687eb79eaeff0da0bc25f1b7f1964cce33612821d984c5f5f0f04e177L78-R79)
* Ensured that date handling in trends and profiles data access supports multiple field names (`date` or `published_date`), and clarified metric aggregation logic. [[1]](diffhunk://#diff-576e0e1f63d3f8e824bb9f83bd289e5e53ce74ff236dfd5c7ca7e9b70757e091L319-R320) [[2]](diffhunk://#diff-ba9a2b3c6516b83ab7228ce889007e8e19b558b8347941234e7207df23953707R1668) [[3]](diffhunk://#diff-ba9a2b3c6516b83ab7228ce889007e8e19b558b8347941234e7207df23953707L1679-R1680) [[4]](diffhunk://#diff-ba9a2b3c6516b83ab7228ce889007e8e19b558b8347941234e7207df23953707L1710-R1711) [[5]](diffhunk://#diff-e8944d30d31376031c44581788fe28ebfd861e3e71e160f39f64120655f5c5fcL558-R558)

**Miscellaneous:**

* Bumped package version from 1.0.0 to 1.0.1 in both `setup.py` and `__init__.py` to reflect these updates. [[1]](diffhunk://#diff-60f61ab7a8d1910d86d9fda2261620314edcae5894d5aaa236b821c7256badd7L15-R15) [[2]](diffhunk://#diff-b736208b243489bb8f4ccaad61d0a1c1b495387125c98560765cefa036a1c9c1L15-R15)
* Improved throughput and latency calculation logic in newsletter scoring to prefer timestamp-based estimates and fall back to serial estimates if needed. [[1]](diffhunk://#diff-fe939a1a7759e247d25a942686a37c300acd42f775d84da6acab79f1a0610c50L311-R312) [[2]](diffhunk://#diff-fe939a1a7759e247d25a942686a37c300acd42f775d84da6acab79f1a0610c50R332-R335) [[3]](diffhunk://#diff-fe939a1a7759e247d25a942686a37c300acd42f775d84da6acab79f1a0610c50L345-R355)